### PR TITLE
Regex, Semicolon fix 

### DIFF
--- a/pytmc/xml_obj.py
+++ b/pytmc/xml_obj.py
@@ -66,13 +66,13 @@ class Configuration:
             raw_config = self._raw_config
 
         # Select special delimiter sequences and prepare them for re injection
-        line_term_seqs = [r";",r";;"]
+        line_term_seqs = [r";",r";;",r"[\n\r]",r"$"]
         flex_term_regex = "|".join(line_term_seqs)
 
 
         # Break configuration str into list of lines paired w/ their delimiters 
         line_finder = re.compile(
-            r"(?P<line>.+?)(?P<delim>"+flex_term_regex+"|[\n\r])"
+            r"(?P<line>.+?)(?P<delim>"+flex_term_regex+")"
         )
         conf_lines = [m.groupdict() for m in line_finder.finditer(raw_config)]
         

--- a/pytmc/xml_obj.py
+++ b/pytmc/xml_obj.py
@@ -86,7 +86,7 @@ class Configuration:
 
         # Break lines into list of dictionaries w/ title/tag structure
         line_parser = re.compile(
-            r"(?P<title>[\S]+):(?:[^\S]+)(?P<tag>.*)"
+            r"(?P<title>[\S]+):(?:[^\S]?)(?P<tag>.*)"
         )
         result = [
             line_parser.search(m).groupdict() for m in result_no_delims

--- a/pytmc/xml_obj.py
+++ b/pytmc/xml_obj.py
@@ -86,7 +86,7 @@ class Configuration:
 
         # Break lines into list of dictionaries w/ title/tag structure
         line_parser = re.compile(
-            r"(?P<title>[\S]+):(?:[^\S]?)(?P<tag>.*)"
+            r"(?P<title>[\S]+):(?:[^\S]*)(?P<tag>.*)"
         )
         result = [
             line_parser.search(m).groupdict() for m in result_no_delims

--- a/pytmc/xml_obj.py
+++ b/pytmc/xml_obj.py
@@ -446,7 +446,10 @@ class Configuration:
         if not self.config_names():
             title_base = ""
         if len(self.config_names()) == 1:
-            title_base = self.config_names()[0]+cc_symbol
+            title_base = self.config_names()[0]
+            if title_base[-1] is not cc_symbol:
+                if title_base.strip() is not "":
+                    title_base = title_base + cc_symbol
         
         for line in other.config:
             # handle config titles

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,19 +114,35 @@ def light_leaf_bool_pragma_string():
 
 @pytest.fixture(scope='function')
 def branch_bool_pragma_string():
-    str = """
+    string = """
             pv: FIRST
             pv: SECOND
     """
-    return str
+    return string
+
+@pytest.fixture(scope='function')
+def branch_bool_pragma_string_empty(branch_bool_pragma_string):
+    string = branch_bool_pragma_string + """
+            pv: 
+            pv:"""
+    
+    return string
 
 @pytest.fixture(scope='function')
 def branch_connection_pragma_string():
-    str = """
+    string = """
             pv: MIDDLE
             aux: nothing
     """
-    return str
+    return string
+
+@pytest.fixture(scope='function')
+def empty_pv_pragma_string():
+    string = """
+            pv:
+    """
+    return string
+    
 
 @pytest.fixture(scope='function')
 def branch_skip_pragma_string():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,10 @@ def leaf_bool_pragma_string_w_semicolon():
     """
     return leaf_bool_pragma_string() + sample_str
 
+@pytest.fixture(scope='function')
+def leaf_bool_pragma_string_single_line():
+    sample_str = """pv:pv_name"""
+    return sample_str
 
 @pytest.fixture(scope='function')
 def light_leaf_bool_pragma_string():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,12 +73,12 @@ def leaf_bool_pragma_string():
                      type: bo 
                      field: ZNAM	SINGLE
                      field: ONAM	MULTI
-                     field: SCAN	1 second
+                     field:   SCAN	1 second
                      str: %d
                      io: o
                      init: True
                      pv: TEST:MAIN:NEW_VAR_IN
-                     type: bi
+                     type:bi
                      field: ZNAM	SINGLE
                      field: ONAM	MULTI
                      field: SCAN	1 second

--- a/tests/test_xml_obj.py
+++ b/tests/test_xml_obj.py
@@ -424,31 +424,43 @@ def test_BaseElement_is_string(string_tmc_root):
     str_symbol_element = BaseElement(symbol_xml)
     assert str_symbol_element.is_str == True
    
+@pytest.mark.parametrize("model_set",[
+    (0),
+    (1),
+])
+def test_Configuration_config_lines(leaf_bool_pragma_string_w_semicolon,
+        leaf_bool_pragma_string_single_line, model_set):
+    if model_set is 0:
+        string = leaf_bool_pragma_string_w_semicolon
+        test =  [
+            {'title': 'pv', 'tag': 'TEST:MAIN:NEW_VAR_OUT'}, 
+            {'title': 'type', 'tag': 'bo'},
+            {'title': 'field', 'tag':'ZNAM\tSINGLE'},
+            {'title': 'field', 'tag':'ONAM\tMULTI'},
+            {'title': 'field', 'tag':'SCAN\t1 second'},
+            {'title': 'str', 'tag': '%d'},
+            {'title': 'io', 'tag': 'o'},
+            {'title': 'init', 'tag': 'True'},
+            {'title': 'pv', 'tag': 'TEST:MAIN:NEW_VAR_IN'}, 
+            {'title': 'type', 'tag': 'bi'},
+            {'title': 'field', 'tag':'ZNAM\tSINGLE'},
+            {'title': 'field', 'tag':'ONAM\tMULTI'},
+            {'title': 'field', 'tag':'SCAN\t1 second'},
+            {'title': 'str', 'tag': '%d'},
+            {'title': 'io', 'tag': 'i'},
+            {'title': 'ensure', 'tag': 'that'},
+            {'title': 'semicolons', 'tag': 'work'},
+        ]
+    if model_set is 1:
+        string = leaf_bool_pragma_string_single_line
+        test = [{'title': "pv", 'tag':'pv_name'}]
 
-def test_Configuration_config_lines(leaf_bool_pragma_string_w_semicolon):
-    print(type(leaf_bool_pragma_string_w_semicolon))
-    print(leaf_bool_pragma_string_w_semicolon)
-    cfg = Configuration(leaf_bool_pragma_string_w_semicolon)
+
+    print(type(string))
+    print(string)
+    cfg = Configuration(string)
     result = cfg._config_lines()
-    assert result == [
-        {'title': 'pv', 'tag': 'TEST:MAIN:NEW_VAR_OUT'}, 
-        {'title': 'type', 'tag': 'bo'},
-        {'title': 'field', 'tag':'ZNAM\tSINGLE'},
-        {'title': 'field', 'tag':'ONAM\tMULTI'},
-        {'title': 'field', 'tag':'SCAN\t1 second'},
-        {'title': 'str', 'tag': '%d'},
-        {'title': 'io', 'tag': 'o'},
-        {'title': 'init', 'tag': 'True'},
-        {'title': 'pv', 'tag': 'TEST:MAIN:NEW_VAR_IN'}, 
-        {'title': 'type', 'tag': 'bi'},
-        {'title': 'field', 'tag':'ZNAM\tSINGLE'},
-        {'title': 'field', 'tag':'ONAM\tMULTI'},
-        {'title': 'field', 'tag':'SCAN\t1 second'},
-        {'title': 'str', 'tag': '%d'},
-        {'title': 'io', 'tag': 'i'},
-        {'title': 'ensure', 'tag': 'that'},
-        {'title': 'semicolons', 'tag': 'work'},
-    ]
+    assert result == test
 
 
 def test_Configuration_neaten_field(leaf_bool_pragma_string):

--- a/tests/test_xml_obj.py
+++ b/tests/test_xml_obj.py
@@ -606,17 +606,21 @@ def test_Configuration__eq__(leaf_bool_pragma_string):
 
 
 def test_Configuration_concat(branch_connection_pragma_string,
-            branch_bool_pragma_string): 
+            branch_bool_pragma_string_empty, empty_pv_pragma_string): 
     cfg_A = Configuration(branch_connection_pragma_string)
-    cfg_B = Configuration(branch_bool_pragma_string)
+    cfg_AA = Configuration(empty_pv_pragma_string)
+    cfg_B = Configuration(branch_bool_pragma_string_empty)
     cfg_B.fix_to_config_name("FIRST")
     new_config = Configuration(config=[])
     new_config.concat(cfg_A)
+    new_config.concat(cfg_AA)
     new_config.concat(cfg_B)
+    print(new_config.config)
     assert new_config.config == [
         {'title':'pv', 'tag':'MIDDLE:FIRST'},
         {'title':'aux', 'tag':'nothing'},
     ]
+    #assert False
 
 
 def test_Configuration_seek():


### PR DESCRIPTION
Bugfixes:
 - Variable whitespace after the first colon is allowed
 - Single line PV's are recognized correctly
 - Multiple colons (or any concatenation symbol) are no longer drawn when PV name strings are skipped