### PR TITLE
BLD: include templates in installed package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,8 @@ setup(
             'xmltranslate = pytmc.bin.xmltranslate:main',
         ]
     },
-    include_package_data = True,
+    package_data={
+      'pytmc': ['templates/*'],
+    },
+    include_package_data=True,
 )


### PR DESCRIPTION
This should properly include templates in the installed package.

Closes #32

cc @domitto 