### PR TITLE
CONDA Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,11 @@ install:
   - source activate pytmc-env
   - pip install -U pip -r requirements.txt -r dev-requirements.txt
   - pip install -e .
-  - pip install coverage codecov
 
 script:
   - coverage run run_tests.py
   - coverage report -m 
   - set -e
-  - pip install doctr
   - cd docs
   - make html
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,13 @@ script:
 
 after_success:
   - codecov
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' ]]; then
+      export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
+      anaconda upload bld-dir/linux-64/*.tar.bz2
+    fi
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' ]]; then
+      export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
+      anaconda upload bld-dir/linux-64/*.tar.bz2
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,17 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
-  - conda install conda-build anaconda-client pip
-  - conda update -q conda
+  - conda install conda-build anaconda-client
+  - conda update -q conda conda-build
+  - conda config --add channels pcds-tag
   # Useful for debugging
   - conda info -a
+  - conda build  -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
+  - conda config --add channels "file://`pwd`/bld-dir"
   # Manage conda environment
-  - conda create -n pytmc-env pip python=$TRAVIS_PYTHON_VERSION
+  - conda create -n pytmc-env python=$TRAVIS_PYTHON_VERSION pytmc pip
   - source activate pytmc-env
-  - pip install -U pip -r requirements.txt -r dev-requirements.txt
-  - pip install -e .
+  - pip install -U pip -r dev-requirements.txt
 
 script:
   - coverage run run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ script:
   - cd ../
   - |
     if [[ $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $BUILD_DOCS ]]; then
-      #doctr deploy . --built-docs docs/_build/html --command "touch .nojekyll; git add .nojekyll"
       doctr deploy . --built-docs docs/_build/html
     fi
 

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,29 @@
+{% set data = load_setup_py_data() %}
+
+package:
+  name: pytmc
+  version : {{ data.get('version') }}
+
+source:
+  path: ..
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - python {{PY_VER}}*,>=3
+    - setuptools
+
+  run:
+    - python {{PY_VER}}*,>=3
+    - jinja2
+
+test:
+  imports:
+    - pytmc
+
+about:
+  home: https://github.com/slaclab/pytmc
+  license: SLAC Open License
+  summary: Generate Epics DB records from TwinCAT .tmc files

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,11 @@
 git+https://github.com/epicsdeb/pypdb.git
 # a pyPDB requirement that is not getting installed:
 ply >=3.4
+coverage
+codecov
+doctr
+pytest
+sphinx==1.6.5
+sphinx-rtd-theme==0.2.4
+sphinxcontrib-websupport==1.0.1
+sphinx_autodoc_typehints==1.3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ coverage
 codecov
 doctr
 pytest
-sphinx==1.6.5
-sphinx-rtd-theme==0.2.4
-sphinxcontrib-websupport==1.0.1
-sphinx_autodoc_typehints==1.3.0
+sphinx
+sphinx-rtd-theme
+sphinxcontrib-websupport
+sphinx_autodoc_typehints

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Jinja2==2.10
+Jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,1 @@
 Jinja2==2.10
-pytest
-Sphinx==1.6.5
-sphinx-rtd-theme==0.2.4
-sphinxcontrib-websupport==1.0.1
-sphinx_autodoc_typehints==1.3.0
-versioneer==0.18


### PR DESCRIPTION
I'd like to get this is in so we can start deploying this on `pcds-tag` this will be necessary to include it as part of our standard Python releases

* Setups a CONDA recipe
* Move a few packages around between `requirements` and `dev-requirements`
* Remove the version specifications on the packages
* Use CONDA to build prior to tests on Travis
* Puts machinery in Travis to deploy built packages to `pcds-tag` and `pcds-dev`