### PR TITLE
ADS Port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Custom
 *.swp
 *.swo
-
+tests/tmc_files/*.db
+tests/tmc_files/invalid/*.db
 
 
 .DS_store

--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -344,7 +344,7 @@ class TmcFile:
         packages. requires self.all_singular_TmcChains to be populated.
         """
         for singular_chain in self.all_singular_TmcChains:
-            brp = BaseRecordPackage(chain=singular_chain)
+            brp = BaseRecordPackage(self.ads_port, chain=singular_chain)
             #brp = BaseRecordPackage(chain=singular_chain, origin=chain)
             self.all_RecordPackages.append(brp)
 
@@ -583,7 +583,7 @@ class BaseRecordPackage:
     _required_keys = {'pv', 'type', 'field'}
     _required_fields = {'DTYP', }
 
-    def __init__(self, chain=None, origin=None):
+    def __init__(self, ads_port, chain=None, origin=None):
         """
         All subclasses should use super on their init method.
         """
@@ -630,7 +630,7 @@ class BaseRecordPackage:
             "asyn_standard_file.jinja2"
         )
 
-        self.ads_port = 851
+        self.ads_port = ads_port
 
     def apply_config_validation(self):
         """

--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -4,6 +4,7 @@ xml_collector.py
 This file contains the objects for intaking TMC files and generating python
 interpretations. Db Files can be produced from the interpretation
 """
+import re
 import logging
 import functools
 import xml.etree.ElementTree as ET

--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -120,6 +120,19 @@ class TmcFile:
             "asyn_standard_file.jinja2"
         )
 
+    @property
+    def ads_port(self):
+        """Return the ADS Port defined in the TMC file under ApplicationName"""
+        if not self.root:
+            return None
+        # Grab the ApplicationName from XML Tree
+        element = self.root.find("./Modules/Module/Properties/"
+                                 "Property/[Name='ApplicationName']")
+        element_value = element.find('./Value').text
+        # Parse the value for the port number and convert
+        port = int(re.search('(\d+)', element_value).group())
+        return port
+
     def isolate_Symbols(self):
         '''
         Populate :attr:`~all_Symbols` with a :class:`~pytmc.Symbol`

--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -122,7 +122,14 @@ class TmcFile:
 
     @property
     def ads_port(self):
-        """Return the ADS Port defined in the TMC file under ApplicationName"""
+        """
+        Return the ADS Port defined in the TMC file under ApplicationName
+
+        Returns
+        -------
+        int:
+            The ADS Port defined in the TMC file under ApplicationName
+        """
         if not self.root:
             return None
         # Grab the ApplicationName from XML Tree

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -637,7 +637,7 @@ def test_BaseRecordPackage_guess_PINI():
 
 
 def test_BaseRecordPackage_guess_TSE():
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(851)
     assert brp.guess_TSE() is True
     [tse] = brp.cfg.get_config_fields('TSE')
     assert tse['tag']['f_set'] == '-2'

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -368,6 +368,11 @@ def test_TmcFile_render(generic_tmc_path):
     assert target_response == tmc.render()
 
 
+def test_TmcFile_ads_port(tmc_filename):
+    tmc = TmcFile(tmc_filename)
+    assert tmc.ads_port == 851
+
+
 # TmcChain tests
 
 def test_TmcChain_forkmap(generic_tmc_path, leaf_bool_pragma_string,

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -262,7 +262,7 @@ def test_TmcFile_create_packages(example_singular_tmc_chains):
         tmc.all_TmcChains.append(cn)
 
         # create the check_set
-        rec = BaseRecordPackage(cn)
+        rec = BaseRecordPackage(851, cn)
         # rec.naive_config()
         # rec.guess_all()
         logger.debug(str(rec.chain.last.pragma.config))
@@ -301,7 +301,7 @@ def test_TmcFile_configure_packages(example_singular_tmc_chains):
         tmc.all_TmcChains.append(cn)
 
         # create the check_set
-        rec = BaseRecordPackage(cn)
+        rec = BaseRecordPackage(None, cn)
         rec.generate_naive_config()
         rec.guess_all()
         logger.debug(str(rec.chain.last.pragma.config))
@@ -330,14 +330,14 @@ def test_TmcFile_fullbuild(string_tmc_path):
 
 def test_TmcFile_render(generic_tmc_path):
     tmc = TmcFile(None)
-    brp1 = BaseRecordPackage()
+    brp1 = BaseRecordPackage(851)
     brp1.cfg.add_config_line('pv', 'example_pv')
     brp1.cfg.add_config_line('type', 'ao')
     brp1.cfg.add_config_field("DTYP", '"MyDTYP"')
     brp1.cfg.add_config_field("PINI", '"VX"')
     brp1.cfg.add_config_field("NELM", 3)
     brp1.cfg.add_config_field('ABC', '"test 0"')
-    brp2 = BaseRecordPackage()
+    brp2 = BaseRecordPackage(851)
     brp2.cfg.add_config_line('pv', 'example_pv2')
     brp2.cfg.add_config_line('type', 'bi')
     brp2.cfg.add_config_field("DTYP", '"MyDTYP"')
@@ -548,7 +548,7 @@ def test_TmcChain_name_list():
 
 def test_BaseRecordPackage_generate_naive_config(sample_TmcChain):
     test_chain = sample_TmcChain.build_singular_chains()[0]
-    brp = BaseRecordPackage(test_chain)
+    brp = BaseRecordPackage(851, test_chain)
     brp.generate_naive_config()
     assert brp.cfg.config[0:3] == [
         {'title': 'pv', 'tag': 'MIDDLE:FIRST:TEST:MAIN:NEW_VAR_OUT'},
@@ -559,7 +559,7 @@ def test_BaseRecordPackage_generate_naive_config(sample_TmcChain):
 
 def test_BaseRecordPackage_apply_config_valid(sample_TmcChain):
     test_chain = sample_TmcChain.build_singular_chains()[0]
-    brp = BaseRecordPackage(test_chain)
+    brp = BaseRecordPackage(851, test_chain)
     brp.generate_naive_config()
     for x in brp.cfg.config:
         print(x)
@@ -579,7 +579,7 @@ def test_BaseRecordPackage_apply_config_valid(sample_TmcChain):
 
 
 def test_BaseRecordPackage_cfg_as_dict():
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(851)
     brp.cfg.add_config_line('pv', 'example_pv')
     brp.cfg.add_config_line('type', 'ao')
     brp.cfg.add_config_field('ABC', 'test 0')
@@ -594,7 +594,7 @@ def test_BaseRecordPackage_cfg_as_dict():
 
 
 def test_BaseRecordPackage_render_record():
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(851)
     brp.cfg.add_config_line('pv', 'example_pv')
     brp.cfg.add_config_line('type', 'ao')
     brp.cfg.add_config_field('DTYP', '"MyDTYP"')
@@ -615,13 +615,13 @@ def test_BaseRecordPackage_render_record():
 
 @pytest.mark.skip(reason="Feature pending")
 def test_BaseRecordPackage_ID_type():
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(851)
     brp.cfg.add_config_line('pv', 'example_pv')
     brp.cfg.add_config_line('type', 'ao')
     brp.cfg.add_config_field("PINI", "1")
     assert brp.ID_type() == 'standard'
 
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(851)
     brp.cfg.add_config_line('pv', 'example_pv')
     brp.cfg.add_config_line('type', 'motor')
     brp.cfg.add_config_field("PINI", "1")
@@ -629,7 +629,7 @@ def test_BaseRecordPackage_ID_type():
 
 
 def test_BaseRecordPackage_guess_PINI():
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(851)
     assert brp.guess_PINI() is True
     print(brp.cfg.config)
     [pini] = brp.cfg.get_config_fields('PINI')
@@ -702,7 +702,7 @@ def test_BaseRecordPackage_guess_type(example_singular_tmc_chains,
     #     z.generate_naive_config()
     #     print(z.cfg.config)
     # assert False
-    record = BaseRecordPackage(example_singular_tmc_chains[0])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[0])
     logger.debug(str(record.chain.last.pragma.config))
     # tc_type is assignable because it isn't implemented in BaseElement
     # this field must be added because it is typically derived from the .tmc
@@ -725,7 +725,7 @@ def test_BaseRecordPackage_guess_type(example_singular_tmc_chains,
 def test_BaseRecordPackage_guess_io(example_singular_tmc_chains,
                                     tc_type, sing_index, final_io):
     # chain must be broken into singular
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     logger.debug(str(record.chain.last.pragma.config))
     # tc_type is assignable because it isn't implemented in BaseElement
     # this field must be added because it is typically derived from the .tmc
@@ -788,7 +788,7 @@ def test_BaseRecordPackage_guess_io(example_singular_tmc_chains,
 def test_BaseRecordPackage_guess_DTYP(example_singular_tmc_chains,
                                       tc_type, io, is_array, final_DTYP):
     # chain must be broken into singular
-    record = BaseRecordPackage(example_singular_tmc_chains[0])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[0])
     logger.debug((record.chain.last.pragma.config))
     # tc_type is assignable because it isn't implemented in BaseElement
     # this field must be added because it is typically derived from the .tmc
@@ -819,7 +819,7 @@ def test_BaseRecordPackage_guess_DTYP(example_singular_tmc_chains,
 def test_BaseRecordPackage_guess_INP_OUT(example_singular_tmc_chains,
                                          tc_type, sing_index, field_type, final_INP_OUT):
     # chain must be broken into singular
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     # tc_type is assignable because it isn't implemented in BaseElement
     # this field must be added because it is typically derived from the .tmc
     record.chain.last.tc_type = tc_type
@@ -857,7 +857,7 @@ def test_BaseRecordPackage_guess_INP_OUT(example_singular_tmc_chains,
 ])
 def test_BaseRecordPackage_guess_SCAN(example_singular_tmc_chains,
                                       tc_type, sing_index, final_SCAN):
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     logger.debug((record.chain.last.pragma.config))
     # tc_type is assignable because it isn't implemented in BaseElement
     # this field must be added because it is typically derived from the .tmc
@@ -876,7 +876,7 @@ def test_BaseRecordPackage_guess_SCAN(example_singular_tmc_chains,
 ])
 def test_BaseRecordPackage_guess_OZ_NAM(example_singular_tmc_chains,
                                         tc_type, sing_index, final_ZNAM, final_ONAM, ret):
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     record.chain.last.tc_type = tc_type
     assert ret == record.guess_ONAM()
     assert ret == record.guess_ZNAM()
@@ -899,7 +899,7 @@ def test_BaseRecordPackage_guess_OZ_NAM(example_singular_tmc_chains,
 ])
 def test_BaseRecordPackage_guess_PREC(example_singular_tmc_chains,
                                       tc_type, sing_index, final_PREC, ret):
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     record.chain.last.tc_type = tc_type
     record.generate_naive_config()
     print(record.cfg.config)
@@ -949,7 +949,7 @@ def test_BaseRecordPackage_guess_PREC(example_singular_tmc_chains,
 ])
 def test_BaseRecordPackage_guess_FTVL(example_singular_tmc_chains,
                                       tc_type, io, is_str, is_arr, final_FTVL):
-    record = BaseRecordPackage(example_singular_tmc_chains[0])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[0])
     record.chain.last.tc_type = tc_type
     record.chain.last.is_array = is_arr
     record.chain.last.is_str = is_str
@@ -975,7 +975,7 @@ def test_BaseRecordPackage_guess_FTVL(example_singular_tmc_chains,
 ])
 def test_BaseRecordPackage_guess_NELM(example_singular_tmc_chains,
                                       tc_type, sing_index, is_str, is_arr, final_NELM):
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     record.chain.last.tc_type = tc_type
     record.chain.last.is_array = is_arr
     record.chain.last.is_str = is_str
@@ -1004,7 +1004,7 @@ def test_BaseRecordPackage_guess_NELM(example_singular_tmc_chains,
     ])
 def test_BaseRecordPackage_guess_all(example_singular_tmc_chains, tc_type,
                                      sing_index, is_str, is_arr, final_NELM, spot_check, result):
-    record = BaseRecordPackage(example_singular_tmc_chains[sing_index])
+    record = BaseRecordPackage(851, example_singular_tmc_chains[sing_index])
     record.chain.last.tc_type = tc_type
     record.chain.last.is_array = is_arr
     record.chain.last.is_str = is_str


### PR DESCRIPTION
The ADS Port can be found in the `tmc` file under `Modules/Module/Properties`. We can not assume that the ADS port will always be the default `851` because certain deployments may have multiple PLCs projects running in one solution, this means these variables will be accessed via different ports.

This PR grabs the ADS port from the TMC file and passes it into each `BaseRecordPackage`. I made `ads_port` are required argument, but this could be relaxed into an optional keyword with a default of `851` if people think that is appropriate and do not want to break API.
