### PR TITLE
ENH: add pytmc-debug GUI tool for inspecting pytmc processing

### DIFF
--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -154,14 +154,6 @@ def show_qt_interface(tmc):
     tmc : TmcFile
         The tmc file to show
     '''
-
-    for pkg in tmc.all_RecordPackages:
-        chain = pkg.chain
-        print(pkg.render_record())
-        print(chain, pkg.origin_chain)
-        print(pkg.cfg)
-        break
-
     app = QtWidgets.QApplication([])
     interface = TmcSummary(tmc)
     interface.show()

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -266,6 +266,20 @@ def main():
               '(requires pyPDB)')
     )
 
+    parser.add_argument(
+        '--log',
+        '-l',
+        metavar="LOG_LEVEL",
+        default=30,  # WARN level messages
+        type=int,
+        help='Python numeric logging level (e.g. 10 for DEBUG, 20 for INFO'
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig()
+    pytmc_logger = logging.getLogger('pytmc')
+    pytmc_logger.setLevel(args.log)
     args = parser.parse_args()
 
     tmc = pytmc.TmcFile(args.tmc_file)

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -95,22 +95,26 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.config_info.clear()
         self.config_info.setRowCount(len(record.cfg.config))
 
-        columns = set()
+        def add_dict_to_table(row, d):
+            for key, value in d.items():
+                key = str(key)
+                if key not in columns:
+                    columns[key] = max(columns.values()) + 1 if columns else 0
+                self.config_info.setItem(
+                    row, columns[key], QtWidgets.QTableWidgetItem(str(value))
+                )
+                if isinstance(value, dict):
+                    add_dict_to_table(row, value)
+
+        columns = {}
         for row, line in enumerate(record.cfg.config):
-            for line_idx, (key, value) in enumerate(line.items()):
-                key_col = line_idx * 2
-                value_col = key_col + 1
-                columns.add(value_col)
-                self.config_info.setItem(
-                    row, key_col, QtWidgets.QTableWidgetItem(str(key))
-                )
-                self.config_info.setItem(
-                    row, value_col, QtWidgets.QTableWidgetItem(str(value))
-                )
+            add_dict_to_table(row, line)
+
+        self.config_info.setHorizontalHeaderLabels(list(columns))
 
         self.config_info.setColumnCount(
-            max(columns) + 1
-            if columns else 1
+            max(columns.values()) + 1
+            if columns else 0
         )
 
     def _update_record_text(self, record):

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -124,8 +124,13 @@ class TmcSummary(QtWidgets.QMainWindow):
             self.chain_info.addItem(str(chain))
 
     def _update_records(self):
-        for record, db_text in self.records.items():
-            names = ' / '.join(_grep_record_names(db_text)) or 'Unknown'
+        self.record_list.clear()
+
+        items = [
+            (' / '.join(_grep_record_names(db_text)) or 'Unknown', record)
+            for record, db_text in self.records.items()
+        ]
+        for names, record in sorted(items, key=lambda item: item[0]):
             item = QtWidgets.QListWidgetItem(names)
             item.setData(Qt.UserRole, record)
             self.record_list.addItem(item)

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -1,0 +1,191 @@
+"""
+"pytmc-debug" is a Qt interface that shows information about how pytmc
+interprets TwinCAT3 .tmc files.
+"""
+
+import argparse
+import logging
+import sys
+
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt, Signal
+
+import pytmc
+from .pytmc import process, LinterError
+
+
+description = __doc__
+
+
+def _grep_record_names(text):
+    if not text:
+        return []
+
+    records = [line.rstrip('{')
+               for line in text.splitlines()
+               if line.startswith('record')
+               ]
+
+    def split_rtyp(line):
+        line = line.split('record(', 1)[1].rstrip('")')
+        rtyp, record = line.split(',', 1)
+        record = record.strip('"\'')
+        return f'{record} ({rtyp})'
+
+    return [split_rtyp(record)
+            for record in records
+            ]
+
+
+class TmcSummary(QtWidgets.QMainWindow):
+    '''
+    pytmc debug interface
+
+    Parameters
+    ----------
+    tmc : TmcFile
+        The tmc file to inspect
+    '''
+
+    record_selected = Signal(object)
+
+    def __init__(self, tmc):
+        super().__init__()
+        self.tmc = tmc
+        self.records = {record: record.render_record()
+                        for record in tmc.all_RecordPackages
+                        }
+
+        self.setWindowTitle(f'pytmc-debug summary - {tmc.filename}')
+
+        self.main_frame = QtWidgets.QFrame()
+        self.layout = QtWidgets.QGridLayout()
+        self.main_frame.setLayout(self.layout)
+        self.setCentralWidget(self.main_frame)
+
+        self.record_list = QtWidgets.QListWidget()
+        self.layout.addWidget(self.record_list, 0, 0, 3, 1)
+
+        self.record_text = QtWidgets.QTextEdit()
+        self.record_text.setFontFamily('Courier New')
+        self.layout.addWidget(self.record_text, 0, 1)
+
+        self.chain_info = QtWidgets.QListWidget()
+        self.layout.addWidget(self.chain_info, 1, 1)
+
+        self.config_info = QtWidgets.QTableWidget()
+        self.layout.addWidget(self.config_info, 2, 1)
+
+        self.record_list.currentItemChanged.connect(
+            self._item_selected)
+
+        self.record_selected.connect(self._update_config_info)
+        self.record_selected.connect(self._update_chain_info)
+        self.record_selected.connect(self._update_record_text)
+
+        self._update_records()
+
+    def _item_selected(self, current, previous):
+        'Slot - new record in list selected'
+        record = current.data(Qt.UserRole)
+        self.record_selected.emit(record)
+
+    def _update_config_info(self, record):
+        'Slot - update config information when a new record is selected'
+        self.config_info.clear()
+        self.config_info.setRowCount(len(record.cfg.config))
+
+        columns = set()
+        for row, line in enumerate(record.cfg.config):
+            for line_idx, (key, value) in enumerate(line.items()):
+                key_col = line_idx * 2
+                value_col = key_col + 1
+                columns.add(value_col)
+                self.config_info.setItem(
+                    row, key_col, QtWidgets.QTableWidgetItem(str(key))
+                )
+                self.config_info.setItem(
+                    row, value_col, QtWidgets.QTableWidgetItem(str(value))
+                )
+
+        self.config_info.setColumnCount(
+            max(columns) + 1
+            if columns else 1
+        )
+
+    def _update_record_text(self, record):
+        'Slot - update record text when a new record is selected'
+        self.record_text.setText(self.records[record])
+
+    def _update_chain_info(self, record):
+        'Slot - update chain information when a new record is selected'
+        self.chain_info.clear()
+        for chain in record.chain.chain:
+            self.chain_info.addItem(str(chain))
+
+    def _update_records(self):
+        for record, db_text in self.records.items():
+            names = ' / '.join(_grep_record_names(db_text)) or 'Unknown'
+            item = QtWidgets.QListWidgetItem(names)
+            item.setData(Qt.UserRole, record)
+            self.record_list.addItem(item)
+
+
+def show_qt_interface(tmc):
+    '''
+    Show the results of tmc processing in a Qt gui
+
+    Parameters
+    ----------
+    tmc : TmcFile
+        The tmc file to show
+    '''
+
+    for pkg in tmc.all_RecordPackages:
+        chain = pkg.chain
+        print(pkg.render_record())
+        print(chain, pkg.origin_chain)
+        print(pkg.cfg)
+        break
+
+    app = QtWidgets.QApplication([])
+    interface = TmcSummary(tmc)
+    interface.show()
+    sys.exit(app.exec_())
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument(
+        'tmc_file', metavar="INPUT", type=str,
+        help='Path to interpreted .tmc file'
+    )
+
+    parser.add_argument(
+        '--dbd',
+        '-d',
+        default=None,
+        type=str,
+        help=('Specify an expanded .dbd file for validating fields '
+              '(requires pyPDB)')
+    )
+
+    args = parser.parse_args()
+
+    tmc = pytmc.TmcFile(args.tmc_file)
+
+    try:
+        process(tmc, dbd_file=args.dbd, allow_errors=True,
+                show_error_context=True)
+    except LinterError:
+        ...
+
+    show_qt_interface(tmc)
+
+
+if __name__ == '__main__':
+    main()

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -58,23 +58,28 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         self.setWindowTitle(f'pytmc-debug summary - {tmc.filename}')
 
-        self.main_frame = QtWidgets.QFrame()
-        self.layout = QtWidgets.QGridLayout()
-        self.main_frame.setLayout(self.layout)
-        self.setCentralWidget(self.main_frame)
+        self.info_frame = QtWidgets.QFrame()
+        self.info_layout = QtWidgets.QVBoxLayout()
+        self.info_frame.setLayout(self.info_layout)
 
+        # Left part of the window
         self.record_list = QtWidgets.QListWidget()
-        self.layout.addWidget(self.record_list, 0, 0, 3, 1)
 
+        # Right part of the window
         self.record_text = QtWidgets.QTextEdit()
         self.record_text.setFontFamily('Courier New')
-        self.layout.addWidget(self.record_text, 0, 1)
-
         self.chain_info = QtWidgets.QListWidget()
-        self.layout.addWidget(self.chain_info, 1, 1)
-
         self.config_info = QtWidgets.QTableWidget()
-        self.layout.addWidget(self.config_info, 2, 1)
+
+        self.info_layout.addWidget(self.record_text)
+        self.info_layout.addWidget(self.chain_info)
+        self.info_layout.addWidget(self.config_info)
+
+        self.splitter = QtWidgets.QSplitter()
+        self.splitter.setOrientation(Qt.Horizontal)
+        self.splitter.addWidget(self.record_list)
+        self.splitter.addWidget(self.info_frame)
+        self.setCentralWidget(self.splitter)
 
         self.record_list.currentItemChanged.connect(
             self._item_selected)

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -11,7 +11,7 @@ from qtpy import QtWidgets
 from qtpy.QtCore import Qt, Signal
 
 import pytmc
-from .pytmc import process, LinterError
+from .pytmc import process
 
 
 description = __doc__
@@ -24,7 +24,9 @@ def _grep_record_names(text):
 
     records = [line.rstrip('{')
                for line in text.splitlines()
-               if line.startswith('record')
+               if line.startswith('record')   # regular line
+               or line.startswith('. record')  # linted line
+               or line.startswith('X record')  # linted error line
                ]
 
     def split_rtyp(line):
@@ -90,7 +92,6 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.records = {}
 
         for record in tmc.all_RecordPackages:
-            record.cfg.add_config_field('ABC', 'test')
             record_text = record.render_record()
             chain_label = ' '.join(record.chain.name_list)
             self.chains[chain_label] = record

--- a/pytmc/bin/pytmc_debug.py
+++ b/pytmc/bin/pytmc_debug.py
@@ -92,10 +92,10 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.records = {}
 
         for record in tmc.all_RecordPackages:
-            record_text = record.render_record()
             chain_label = ' '.join(record.chain.name_list)
             self.chains[chain_label] = record
             try:
+                record_text = record.render_record()
                 linter_results = (pytmc.epics.lint_db(dbd, record_text)
                                   if dbd and record_text else None)
                 record_text = _annotate_record_text(linter_results,

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     entry_points = {
         'console_scripts': [
             'pytmc = pytmc.bin.pytmc:main',
+            'pytmc-debug = pytmc.bin.pytmc_debug:main',
             'xmltranslate = pytmc.bin.xmltranslate:main',
         ]
     },

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -24,8 +24,8 @@ ALL_TMC_FILES = conftest.TMC_FILES + conftest.INVALID_TMC_FILES
 def test_db_linting(dbd_file, tmp_path, filename):
     db_fn = tmp_path / '{}.db'.format(filename)
     tmc_file = pytmc.TmcFile(filename)
-    db_text = pytmc.bin.pytmc.make_db_text(tmc_file, dbd_file=dbd_file,
-                                           allow_errors=True)
+    pytmc.bin.pytmc.process(tmc_file, dbd_file=dbd_file, allow_errors=True)
+    db_text = tmc_file.render()
     with open(db_fn, 'wt') as f:
         print(db_text, file=f)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5139267/56928263-1cf00080-6a8b-11e9-8130-b26c10bb47ba.png)

Although this script has a dependency on `qtpy` (and therefore `PyQt5`/`Qt5`/etc), I think it can be considered optional. I had intended to make a command line-only alternative to the Qt version, but I'm not sure it's worthwhile.