### PR TITLE
PERF: reduce amount of deepcopy calls in build_singular_chains

### DIFF
--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -566,21 +566,20 @@ class TmcChain:
             List of TmcChains. Each chain is bound to one of the possible paths
             given the configurations available at each step.
         """
-        name_sequences = self._recursive_permute(self.forkmap())
+        forkmap = self.forkmap()
+        name_sequences = self._recursive_permute(forkmap)
         logging.debug(str(name_sequences))
+        if any(config.pragma is None for config in self.chain):
+            return []
+
         results = []
-        append = True
+
         for seq in name_sequences:
             new_TmcChain = deepcopy(self)
+            results.append(new_TmcChain)
+
             for config, select_name in zip(new_TmcChain.chain, seq):
-                if config.pragma is not None:
-                    config.pragma.fix_to_config_name(select_name[0])
-                else:
-                    append = False
-            if append:
-                results.append(new_TmcChain)
-            else:
-                append = True
+                config.pragma.fix_to_config_name(select_name[0])
         return results
 
     def naive_config(self, cc_symbol=":"):

--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -469,7 +469,7 @@ class TmcChain:
         """
         full_list = []
         for entry in self.chain:
-            logger.debug(str(entry))
+            logger.debug('Forkmap entry: %s', entry)
             if entry.pragma is None:
                 full_list.append([])
             else:

--- a/pytmc/xml_obj.py
+++ b/pytmc/xml_obj.py
@@ -818,7 +818,7 @@ class BaseElement:
         if self.element is None:
             name = "None"
         else:
-            name = "<xml(" + self.element.find("./Name").text + ")>"
+            name = "<xml(" + self.name + ")>"
 
         return "{}(element={})".format(
             self.__class__.__name__,
@@ -838,9 +838,8 @@ class BaseElement:
             The name of the variable
         '''
         if self._cached_name is None:
-            return self._get_subfield("Name").text
-        else:
-            return self._cached_name
+            self._cached_name = self._get_subfield("Name").text
+        return self._cached_name
 
     @name.setter
     def name(self, name):

--- a/pytmc/xml_obj.py
+++ b/pytmc/xml_obj.py
@@ -207,8 +207,9 @@ class Configuration:
 
         specific_configs = self._config_by_name(formatted_config_lines)
 
+        item = {'title': self.cfg_header, 'tag': config_name}
         for spec_config in specific_configs:
-            if {'title': self.cfg_header, 'tag': config_name} in spec_config:
+            if item in spec_config:
                 return spec_config
 
         return []


### PR DESCRIPTION
This appears to be at the core of https://github.com/slaclab/pytmc/issues/82.

It was not an infinite loop as I had guessed, but it was taking on the order of minutes and gigabytes of memory due to unnecessary deepcopy calls.

With the current master, I gave up after 2 minutes of waiting:

![image](https://user-images.githubusercontent.com/5139267/59804719-ffc5fa00-92a3-11e9-8247-6cdc222d0f4d.png)

With this PR, it goes at a not-so-unreasonable speed:

```sh
$ time pytmc --allow-errors VonHamos01.tmc test.db

real    0m9.965s
user    0m9.776s
sys     0m0.157s
```