### PR TITLE
FIX: AMS ID is on the TopLevelProject

### DIFF
--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -46,7 +46,7 @@ def build_arg_parser(parser=None):
 
     parser.add_argument(
         '--binary', type=str, dest='binary_name',
-        default='adsMotion',
+        default='adsIoc',
         help='IOC application binary name'
     )
 

--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -145,6 +145,9 @@ def main(tsproj_project, use_markdown=False, show_all=False,
             heading(f'PLC Project ({i}): {plc.project_path.stem}')
             print(f'    Project path: {plc.project_path}')
             print(f'    TMC path:     {plc.tmc_path}')
+            print(f'    AMS ID:       {plc.ams_id}')
+            print(f'    IP Address:   {plc.target_ip} (* based on AMS ID)')
+            print(f'    Port:         {plc.port}')
             print(f'')
             proj_info = [('Source files', plc.source_filenames),
                          ('POUs', plc.pou_by_name),

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -324,7 +324,24 @@ class Link(TwincatItem):
 
 
 class TopLevelProject(TwincatItem):
-    '[tsproj] '
+    '[tsproj] Containing Io, System, Motion, TopLevelPlc, etc.'
+
+    @property
+    def ams_id(self):
+        '''
+        The AMS ID of the configured target
+        '''
+        return self.attributes.get('TargetNetId', '')
+
+    @property
+    def target_ip(self):
+        '''
+        A guess of the target IP, based on the AMS ID
+        '''
+        ams_id = self.ams_id
+        if ams_id.endswith('.1.1'):
+            return ams_id[:-4]
+        return ams_id  # :(
 
 
 class PlcProject(TwincatItem):
@@ -475,6 +492,7 @@ class Plc(TwincatItem):
         '''
         The AMS ID of the configured target
         '''
+        return self.find_ancestor(TopLevelProject).ams_id
         return self.attributes.get('TargetNetId', '')
 
     @property
@@ -482,10 +500,7 @@ class Plc(TwincatItem):
         '''
         A guess of the target IP, based on the AMS ID
         '''
-        ams_id = self.ams_id
-        if ams_id.endswith('.1.1'):
-            return ams_id[:-4]
-        return ams_id  # :(
+        return self.find_ancestor(TopLevelProject).target_ip
 
     def find(self, cls, *, recurse=True):
         yield from super().find(cls, recurse=recurse)


### PR DESCRIPTION
cc @zllentz - as we ran into this yesterday.

Output from the project during the demo:
```
$ pytmc summary --plcs tests/projects/motion-demo/motion-demo/motion-demo/motion-demo.tsproj
PLC Project (1): Demo1
======================

    Project path: /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo1/Demo1.plcproj
    TMC path:     /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo1/Demo1.tmc
    AMS ID:       5.57.239.146.1.1
    IP Address:   5.57.239.146 (* based on AMS ID)
    Port:         851

    Source files:
        1.) /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo1/PlcTask.TcTTO
        2.) /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo1/POUs/Main.TcPOU

    POUs:
        1.) Main

PLC Project (2): Demo2
======================

    Project path: /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo2/Demo2.plcproj
    TMC path:     /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo2/Demo2.tmc
    AMS ID:       5.57.239.146.1.1
    IP Address:   5.57.239.146 (* based on AMS ID)
    Port:         852

    Source files:
        1.) /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo2/PlcTask.TcTTO
        2.) /Users/klauer/docs/Repos/pytmc/tests/projects/motion-demo/motion-demo/motion-demo/Demo2/POUs/Main.TcPOU

    POUs:
        1.) Main
```