### PR TITLE
ENH: pytmc-iocboot

### DIFF
--- a/pytmc/bin/iocboot.py
+++ b/pytmc/bin/iocboot.py
@@ -11,10 +11,9 @@ import pathlib
 
 import jinja2
 
-from . import db, util
-from .. import pragmas
+from . import util
 
-from ..parser import parse, Symbol, separate_by_classname
+from ..parser import parse
 
 
 DESCRIPTION = __doc__
@@ -89,7 +88,6 @@ def main(tsproj_project, ioc_template_path, *, prefix='ioc-', debug=False,
     project = parse(tsproj_project)
 
     solution_path = tsproj_project.parent.parent
-    repo_path = solution_path.parent
 
     ioc_template_path = pathlib.Path(ioc_template_path)
     makefile_template_path = ioc_template_path / makefile_name
@@ -152,8 +150,8 @@ def main(tsproj_project, ioc_template_path, *, prefix='ioc-', debug=False,
                     raise stashed_exception
 
                 if makefile_path.exists() and not overwrite:
-                    raise RuntimeError('Must specify --overwrite to write over '
-                                       'existing Makefiles')
+                    raise RuntimeError('Must specify --overwrite to write over'
+                                       ' existing Makefiles')
                 with open(makefile_path, 'wt') as f:
                     print(rendered, file=f)
 

--- a/pytmc/bin/iocboot.py
+++ b/pytmc/bin/iocboot.py
@@ -1,0 +1,169 @@
+"""
+"pytmc iocboot" is a command line utility for bootstrapping new EPICS IOCs
+based on TwinCAT3 .tsproj projects.
+"""
+
+import argparse
+import getpass
+import logging
+import os
+import pathlib
+
+import jinja2
+
+from . import db, util
+from .. import pragmas
+
+from ..parser import parse, Symbol, separate_by_classname
+
+
+DESCRIPTION = __doc__
+logger = logging.getLogger(__name__)
+
+
+def build_arg_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    parser.description = DESCRIPTION
+    parser.formatter_class = argparse.RawTextHelpFormatter
+
+    parser.add_argument(
+        'tsproj_project', type=str,
+        help='Path to .tsproj project'
+    )
+
+    parser.add_argument(
+        'ioc_template_path', type=str,
+        help='Path to IOC template directory'
+    )
+
+    parser.add_argument(
+        '--prefix', type=str, default='ioc-',
+        help='IOC boot directory prefix [default: ioc-]'
+    )
+
+    parser.add_argument(
+        '--makefile-name', type=str,
+        default='Makefile.ioc',
+        help='Jinja2 template for the IOC Makefile [default: Makefile.ioc]',
+    )
+
+    parser.add_argument(
+        '--overwrite', action='store_true',
+        help='Overwrite existing files'
+    )
+
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Dry-run only - do not write files'
+    )
+
+    parser.add_argument(
+        '--plcs',
+        type=str,
+        action='append',
+        help='Specify one or more PLC names to generate'
+    )
+
+    parser.add_argument(
+        '--debug', '-d',
+        action='store_true',
+        help='Post-stcmd, open an interactive Python session'
+    )
+
+    return parser
+
+
+def main(tsproj_project, ioc_template_path, *, prefix='ioc-', debug=False,
+         overwrite=False, makefile_name='Makefile.ioc', dry_run=False,
+         plcs=None):
+    jinja_env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(ioc_template_path),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+    tsproj_project = pathlib.Path(tsproj_project).expanduser().absolute()
+    project = parse(tsproj_project)
+
+    solution_path = tsproj_project.parent.parent
+    repo_path = solution_path.parent
+
+    ioc_template_path = pathlib.Path(ioc_template_path)
+    makefile_template_path = ioc_template_path / makefile_name
+    if not makefile_template_path.exists():
+        raise RuntimeError(f'File not found: {makefile_template_path}')
+
+    template = jinja_env.get_template(makefile_name)
+
+    for plc_name, plc in project.plcs_by_name.items():
+        if plcs is not None and plc_name not in plcs:
+            continue
+
+        ioc_path = pathlib.Path(f'{prefix}{plc_name}').absolute()
+        if not dry_run:
+            os.makedirs(ioc_path, exist_ok=True)
+        makefile_path = ioc_path / 'Makefile'
+
+        plc_path = pathlib.Path(plc.filename).parent
+        template_args = dict(
+            project_name=tsproj_project.stem,
+            plc_name=plc_name,
+            tsproj_path=os.path.relpath(tsproj_project, ioc_path),
+            project_path=os.path.relpath(tsproj_project.parent, ioc_path),
+            template_path=ioc_template_path,
+            solution_path=os.path.relpath(solution_path, ioc_path),
+            plcproj=os.path.relpath(plc.filename, ioc_path),
+            plc_path=os.path.relpath(plc_path, ioc_path),
+            plc_ams_id=plc.ams_id,
+            plc_ip=plc.target_ip,
+            plc_ads_port=plc.port,
+            user=getpass.getuser(),
+        )
+
+        stashed_exception = None
+        try:
+            rendered = template.render(**template_args)
+        except Exception as ex:
+            stashed_exception = ex
+            rendered = None
+
+        if not debug:
+            if dry_run:
+                print()
+                print('---' * 30)
+                print(makefile_path)
+                print('---' * 30)
+
+                if stashed_exception is not None:
+                    print('Failed:', type(stashed_exception).__name__,
+                          stashed_exception)
+                    print()
+                else:
+                    if makefile_path.exists():
+                        print('** OVERWRITING **'
+                              if overwrite else '** FAIL: already exists **')
+                        print()
+                    print(rendered)
+            else:
+                if stashed_exception is not None:
+                    raise stashed_exception
+
+                if makefile_path.exists() and not overwrite:
+                    raise RuntimeError('Must specify --overwrite to write over '
+                                       'existing Makefiles')
+                with open(makefile_path, 'wt') as f:
+                    print(rendered, file=f)
+
+        else:
+            message = ['Variables: project, plc, template ']
+            if stashed_exception is not None:
+                message.append(f'Exception: {type(stashed_exception)} '
+                               f'{stashed_exception}')
+
+            util.python_debug_session(
+                namespace=locals(),
+                message='\n'.join(message)
+            )

--- a/pytmc/bin/pytmc.py
+++ b/pytmc/bin/pytmc.py
@@ -13,7 +13,8 @@ import logging
 DESCRIPTION = __doc__
 
 
-MODULES = ('summary', 'stcmd', 'db', 'xmltranslate', 'debug', 'types')
+MODULES = ('summary', 'stcmd', 'db', 'xmltranslate', 'debug', 'types',
+           'iocboot')
 
 
 def _try_import(module):

--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -154,7 +154,7 @@ def main(tsproj_project, *, name=None, prefix=None,
         [
             jinja2.PackageLoader("pytmc", "templates"),
             jinja2.FileSystemLoader(template_path),
-         ]
+        ]
     )
     jinja_env = jinja2.Environment(
         loader=jinja_loader,

--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -45,6 +45,12 @@ def build_arg_parser(parser=None):
     )
 
     parser.add_argument(
+        '--hashbang', type=str,
+        default='../../bin/rhel7-x86_64/adsIoc',
+        help='Indicates to the shell which binary to use for the st.cmd script'
+    )
+
+    parser.add_argument(
         '--binary', type=str, dest='binary_name',
         default='adsIoc',
         help='IOC application binary name'
@@ -149,7 +155,8 @@ def jinja_filters(**user_config):
 def main(tsproj_project, *, name=None, prefix=None,
          template_filename='stcmd_default.cmd', plc_name=None, dbd=None,
          db_path='.', only_motor=False, binary_name='ads', delim=':',
-         template_path='.', debug=False, allow_errors=False):
+         template_path='.', debug=False, allow_errors=False,
+         hashbang='../../bin/rhel7-x86_64/adsIoc'):
     jinja_loader = jinja2.ChoiceLoader(
         [
             jinja2.PackageLoader("pytmc", "templates"),
@@ -220,6 +227,7 @@ def main(tsproj_project, *, name=None, prefix=None,
                                'is not an issue.')
 
     template_args = dict(
+        hashbang=hashbang,
         binary_name=binary_name,
         name=name,
         prefix=prefix,

--- a/pytmc/templates/stcmd_default.cmd
+++ b/pytmc/templates/stcmd_default.cmd
@@ -1,4 +1,4 @@
-#!../../bin/rhel7-x86_64/{{binary_name}}
+#!{{hashbang}}
 
 < envPaths
 epicsEnvSet("IOCNAME", "{{name}}" )


### PR DESCRIPTION
Couples with pcdshub/ads-ioc#7

General idea is the following:

```bash
$ pytmc iocboot /path/to/plc.tsproj /path/to/ads-ioc/iocBoot/templates/
# Creates directories: ioc-plc-name1, ioc-plc-name2, ...
# Creates Makefiles: ioc-plc-name/Makefile

$ cd ioc-plc-name
$ vim Makefile
# Customize - if necessary - to add more db files or change pytmc stcmd options

$ make
# Shells out to pytmc stcmd;
# Creates st.cmd, ioc-plc-name.db, envPaths

$ ./st.cmd
# Runs IOC
```

Remaining:
- [x] Binary location
- [x] envPaths generation / copying?
- [ ] Archiver request files (maybe)