### PR TITLE
FIX: strings only work with asynInt8Array with twincat-ads

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -374,18 +374,18 @@ class StringRecordPackage(TwincatTypeRecordPackage):
     """RecordPackage for broadcasting string values"""
     input_rtyp = 'waveform'
     output_rtyp = 'waveform'
-    dtyp = 'asynOctet'
+    dtyp = 'asynInt8'
     field_defaults = {'FTVL': 'CHAR', 'NELM': '81'}
 
     def generate_input_record(self):
         record = super().generate_input_record()
-        record.fields['DTYP'] += 'Read'
+        record.fields['DTYP'] += 'ArrayIn'
         return record
 
     def generate_output_record(self):
         record = super().generate_output_record()
-        record.fields['DTYP'] += 'Write'
         # Waveform records only have INP fields!
+        record.fields['DTYP'] += 'ArrayOut'
         record.fields['INP'] = record.fields.pop('OUT')
         return record
 

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -86,8 +86,8 @@ def test_record_package_from_chain(chain, tc_type, is_array, final_type,
     ("ENUM", 'io', False, 'asynInt32'),
     ("ENUM", 'i', True, 'asynInt16ArrayIn'),
     ("ENUM", 'io', True, 'asynInt16ArrayOut'),
-    ("STRING", 'i', False, 'asynOctetRead'),
-    ("STRING", 'io', False, 'asynOctetWrite'),
+    ("STRING", 'i', False, 'asynInt8ArrayIn'),
+    ("STRING", 'io', False, 'asynInt8ArrayOut'),
 ])
 def test_dtype(chain, tc_type, io, is_array, final_DTYP):
     chain.data_type = make_mock_type(tc_type, is_array=is_array, length=3)


### PR DESCRIPTION
Closes #97 

Reference:

https://github.com/pcdshub/twincat-ads/blob/24f81b23c52355ea0088bebd509680470e5f24b5/adsApp/src/adsAsynPortDriver.cpp#L3895

Tested on IOC (now that I finally have access with my VM!)
```
ADS_TST:Str this is a test
ADS_TST:Str_RBV 2019-08-13 16:10:14.993000 this is a test
```