### PR TITLE
FIX: default io type should be io, as per the docs

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -171,7 +171,7 @@ class TwincatTypeRecordPackage(RecordPackage):
         ValueError
             If unable to determine IO direction
         """
-        io = self.chain.config.get('io', 'i')
+        io = self.chain.config.get('io', 'io')
         if 'o' in io:
             return 'output'
         return 'input'


### PR DESCRIPTION
https://slaclab.github.io/pytmc/pragma_usage.html#io