### PR TITLE
FIX: Ignore invalid pytmc symbols

### DIFF
--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -243,7 +243,8 @@ def find_pytmc_symbols(tmc):
     'Find all symbols in a tmc file that contain pragmas'
     for symbol in tmc.find(parser.Symbol):
         if has_pragma(symbol):
-            yield symbol
+            if symbol.name.count('.') == 1:
+                yield symbol
 
 
 def get_pragma(item, *, name='pytmc'):


### PR DESCRIPTION
This gets rid of two kinds of invalid symbols:
- duplicates, where symbol leafs are doubled-up with their containing
  structure
- invalid symbols, where there is not a complete pragma path from
  top-level down to the symbol itself

The tmc file can have duplicate or bogus pytmc symbol entries for anything that is marked as an input or an output variable. The correct symbols to use are the symbols with only two dot-separated fields, such as `GVL.bInput` or `Main.stStruct`, not `Main.stStruct.bOutput` which is actually a double-count.