### PR TITLE
CI: Qt installation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,8 @@ install:
   - conda build  -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
   # Manage conda environment
-  - conda create -n pytmc-env python=$TRAVIS_PYTHON_VERSION pytmc pip
+  - conda create -n pytmc-env python=$TRAVIS_PYTHON_VERSION pytmc pip pyqt --file dev-requirements.txt
   - source activate pytmc-env
-  - conda install --file dev-requirements.txt
 
 before_script:
   # Run windows manager

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
   - conda config --add channels pcds-tag
+  - conda config --append channels conda-forge
   # Useful for debugging
   - conda info -a
   - conda build  -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
@@ -38,7 +39,7 @@ install:
   # Manage conda environment
   - conda create -n pytmc-env python=$TRAVIS_PYTHON_VERSION pytmc pip
   - source activate pytmc-env
-  - pip install -U pip -r dev-requirements.txt
+  - conda install --file dev-requirements.txt
 
 before_script:
   # Run windows manager

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,6 @@ codecov
 coverage
 doctr
 flake8
-pyqt5
 pytest
 pytest-qt
 qtpy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,6 @@ pytest-qt
 qtpy
 sphinx
 sphinx-argparse
-sphinx-rtd-theme
-sphinx_autodoc_typehints
+sphinx_rtd_theme
+sphinx-autodoc-typehints
 sphinxcontrib-websupport


### PR DESCRIPTION
Fixes the issues we are seeing install Qt via `pip` on Travis. Don't really know why the pip version was working but I know that we will deploy this system with the CONDA version so it is probably best to test with it on the CI.

As a side note, I removed Qt from all of the requirements. Installing it is really a mess so I think it is probably best to just depend on `qtpy` and leave the actual `Qt` installation as an individual choice. It is almost impossible to have a setup that works with both `pip` and `CONDA` if we do not go this route.



