### PR TITLE
FIX: arrays and string waveform NELM

### DIFF
--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -654,6 +654,13 @@ class SubItem(_TmcItem):
         return self.tmc.get_data_type(self.qualified_type_name)
 
     @property
+    def array_info(self):
+        try:
+            return self.ArrayInfo[0]
+        except (AttributeError, IndexError):
+            return None
+
+    @property
     def type(self):
         'The base type'
         return self.Type[0].text

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -227,6 +227,7 @@ class SingularChain:
         self.chain = list(self.item_to_config)
         self.last = self.chain[-1]
         self.data_type = self.chain[-1].data_type
+        self.array_info = self.chain[-1].array_info
         self.tcname = '.'.join(part.name for part in self.chain)
 
         self.config = squash_configs(*list(item_to_config.values()))

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -381,11 +381,17 @@ class StringRecordPackage(TwincatTypeRecordPackage):
     input_rtyp = 'waveform'
     output_rtyp = 'waveform'
     dtyp = 'asynInt8'
-    field_defaults = {'FTVL': 'CHAR', 'NELM': '81'}
+    field_defaults = {'FTVL': 'CHAR'}
+
+    @property
+    def nelm(self):
+        """Number of elements in record"""
+        return self.chain.data_type.length or '81'
 
     def generate_input_record(self):
         record = super().generate_input_record()
         record.fields['DTYP'] += 'ArrayIn'
+        record.fields['NELM'] = self.nelm
         return record
 
     def generate_output_record(self):
@@ -393,6 +399,7 @@ class StringRecordPackage(TwincatTypeRecordPackage):
         # Waveform records only have INP fields!
         record.fields['DTYP'] += 'ArrayOut'
         record.fields['INP'] = record.fields.pop('OUT')
+        record.fields['NELM'] = self.nelm
         return record
 
 

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -99,7 +99,7 @@ class RecordPackage:
     def from_chain(*args, chain, **kwargs):
         """Select the proper subclass of ``TwincatRecordPackage`` from chain"""
         data_type = chain.data_type
-        if data_type.is_array:
+        if data_type.is_array or chain.last.array_info:
             spec = WaveformRecordPackage
         elif data_type.is_string:
             spec = StringRecordPackage
@@ -323,7 +323,9 @@ class WaveformRecordPackage(TwincatTypeRecordPackage):
     @property
     def nelm(self):
         """Number of elements in record"""
-        return self.chain.data_type.length
+        if self.chain.data_type.is_array:
+            return self.chain.data_type.length
+        return self.chain.array_info.elements
 
     @property
     def dtyp(self):


### PR DESCRIPTION
Discovered by @ZLLentz, this bug caused arrays to be represented as scalar records (i.e., not `waveform`) in the EPICS db.

This now generates what appears to be correct to me:
```
record(waveform, "TST:PPM:SPM:VOLT_BUFFER_RBV"){
  field(PINI, "1")
  field(TSE, "-2")
  field(INP, "@asyn($(PORT),0,1)ADSPORT=851/Main.fbPPM.stPPM.stPowerMeter.fVoltageBuffer?")
  field(DTYP, "asynFloat64ArrayIn")
  field(SCAN, "I/O Intr")
  field(FTVL, "DOUBLE")
  field(NELM, "1000")
}

record(waveform, "TST:PPM:SPM:MJ_BUFFER_RBV"){
  field(PINI, "1")
  field(TSE, "-2")
  field(INP, "@asyn($(PORT),0,1)ADSPORT=851/Main.fbPPM.stPPM.stPowerMeter.fCalibMJBuffer?")
  field(DTYP, "asynFloat64ArrayIn")
  field(SCAN, "I/O Intr")
  field(FTVL, "DOUBLE")
  field(NELM, "1000")
}
```

(This also shows we have a _lot_ of holes in the test suite, which probably shouldn't be a surprise given how much I thrashed it...)