### PR TITLE
ENH: error on duplicate records generated

### DIFF
--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -105,6 +105,19 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
                for record in record_packages_from_symbol(symbol)
                ]
 
+    record_names = [record.pvname for record in records]
+    if len(record_names) != len(set(record_names)):
+        dupes = {name: record_names.count(name)
+                 for name in record_names
+                 if record_names.count(name) > 1
+                 }
+        message = '\n'.join(['Duplicate records encountered:'] +
+                            [f'    {dupe} ({count})'
+                             for dupe, count in sorted(dupes.items())])
+        logger.error(message)
+        if not allow_errors:
+            raise LinterError(message)
+
     if dbd_file is not None:
         results, rendered = validate_with_dbd(records, dbd_file)
         for warning in results.warnings:

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -114,9 +114,9 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
         message = '\n'.join(['Duplicate records encountered:'] +
                             [f'    {dupe} ({count})'
                              for dupe, count in sorted(dupes.items())])
-        logger.error(message)
         if not allow_errors:
             raise LinterError(message)
+        logger.error(message)
 
     if dbd_file is not None:
         results, rendered = validate_with_dbd(records, dbd_file)


### PR DESCRIPTION
Closes #96 

Looks like:
```sh
$ pytmc db TC_project/TwinCAT\ Project1/TwinCAT\ Project1/Untitled1/Untitled1.tmc
ERROR:pytmc.bin.db:Duplicate records encountered:
    ADS_TST:ReadOnly:Str (2)
    ADS_TST:ReadOnly:bArray (2)
    ADS_TST:ReadOnly:bState (2)
```