### PR TITLE
FIX: be better about showing linter errors to user

### DIFF
--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -193,7 +193,7 @@ def main(tmc_file, record_file=None, *, dbd=None, allow_errors=False,
             tmc, dbd_file=dbd, allow_errors=allow_errors,
             show_error_context=not no_error_context,
         )
-    except LinterError as ex:
+    except LinterError:
         logger.exception(
             'Linter errors - failed to create database. To create the database'
             ' ignoring these errors, use the flag `--allow-errors`')

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -134,9 +134,6 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
             if show_error_context:
                 _show_context_from_line(rendered, error['line'])
         if not results.success and not allow_errors:
-            logger.error('Linter errors - failed to create database. '
-                         'To disable this behavior, use the flag '
-                         '--allow-errors')
             raise LinterError('Failed to create database')
 
     return records
@@ -196,7 +193,10 @@ def main(tmc_file, record_file=None, *, dbd=None, allow_errors=False,
             tmc, dbd_file=dbd, allow_errors=allow_errors,
             show_error_context=not no_error_context,
         )
-    except LinterError:
+    except LinterError as ex:
+        logger.exception(
+            'Linter errors - failed to create database. To create the database'
+            ' ignoring these errors, use the flag `--allow-errors`')
         sys.exit(1)
 
     db_string = '\n\n'.join(record.render() for record in records)


### PR DESCRIPTION
The behavior of the duplicate record checker from `pytmc db` meant that pytmc could bail silently, as discovered by @domitto.

Now, it will result in the following:
```
$ pytmc db GmdPlc-20190822.tmc
ERROR:pytmc.bin.db:Linter errors - failed to create database. To create the database ignoring these errors, use the flag `--allow-errors`
Traceback (most recent call last):
  File "/Users/klauer/docs/Repos/pytmc/pytmc/bin/db.py", line 194, in main
    show_error_context=not no_error_context,
  File "/Users/klauer/docs/Repos/pytmc/pytmc/bin/db.py", line 118, in process
    raise LinterError(message)
pytmc.bin.db.LinterError: Duplicate records encountered:
    fb_EM1K0_GMD_GCC_10:PRESS (2)
    fb_EM1K0_GMD_GCC_20:PRESS (2)
    fb_EM1K0_GMD_GCC_30:PRESS (2)
    fb_EM1K0_GMD_GCC_40:PRESS (2)
    fb_EM1K0_GMD_GCC_50:PRESS (2)
    fb_EM1K0_GMD_GCC_60:PRESS (2)
    fb_EM1K0_GMD_GCC_70:PRESS (2)
    fb_EM1K0_GMD_GPI_10:PRESS (2)
    fb_EM1K0_GMD_GPI_40:PRESS (2)
    fb_EM1K0_GMD_GPI_70:PRESS (2)
```