### PR TITLE
FIX: pragma can be None, somehow

### DIFF
--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -259,7 +259,8 @@ def get_pragma(item, *, name='pytmc'):
 
 def has_pragma(item, *, name='pytmc'):
     'Does `item` have a pragma titled `name`?'
-    return any(True for _ in get_pragma(item, name=name))
+    return any(True for pragma in get_pragma(item, name=name)
+               if pragma is not None)
 
 
 def chains_from_symbol(symbol, *, pragma='pytmc'):


### PR DESCRIPTION
q_iRawPosition in plc_kfe_xgmd_vac.tmc

`L2SI_Vacuum_Library.ST_VCN`:
```
<SubItem>
    <Name>q_iRawPosition</Name>
    <Type>INT</Type>
    <Comment><![CDATA[Position control ]]></Comment>
    <BitSize>16</BitSize>
    <BitOffs>32</BitOffs>
    <Properties>
        <Property>
            <Name>pytmc</Name>
        </Property>
    </Properties>
</SubItem>
```