### PR TITLE
ENH: add pragma linter utility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tests/projects/vonhamos-motion"]
 	path = tests/projects/vonhamos-motion
 	url = ../../pcdshub/vonhamos-motion
+[submodule "tests/projects/lcls-plc-kfe-xgmd-vac"]
+	path = tests/projects/lcls-plc-kfe-xgmd-vac
+	url = ../../lcls-plc-kfe-xgmd-vac.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = ../../pcdshub/vonhamos-motion
 [submodule "tests/projects/lcls-plc-kfe-xgmd-vac"]
 	path = tests/projects/lcls-plc-kfe-xgmd-vac
-	url = ../../lcls-plc-kfe-xgmd-vac.git
+	url = ../../pcdshub/lcls-plc-kfe-xgmd-vac.git

--- a/pytmc/bin/pragmalint.py
+++ b/pytmc/bin/pragmalint.py
@@ -1,0 +1,172 @@
+"""
+"pytmc pragmalint" is a command line utility for linting PyTMC pragmas in a
+given TwinCAT project or source code file
+"""
+
+import argparse
+import logging
+import pathlib
+import re
+import sys
+import textwrap
+
+from .. import parser
+from . import util
+from .db import LinterError
+
+
+DESCRIPTION = __doc__
+logger = logging.getLogger(__name__)
+
+PRAGMA_START_RE = re.compile('{attribute')
+PRAGMA_RE = re.compile(
+    r"^{\s*attribute[ \t]+'pytmc'[ \t]*:=[ \t]*'([\s\S]*)'}$",
+    re.MULTILINE
+)
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+    argparser.add_argument(
+        'filename', type=str,
+        help='Path to .tsproj project or source code file'
+    )
+
+    argparser.add_argument(
+        '--markdown', dest='use_markdown',
+        action='store_true',
+        help='Make output more markdown-friendly, for easier sharing'
+    )
+
+    argparser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Show all pragmas, including good ones'
+    )
+
+    return argparser
+
+
+def match_single_pragma(code):
+    curly_count = 0
+    for i, char in enumerate(code):
+        if char == '{':
+            curly_count += 1
+        elif char == '}':
+            curly_count -= 1
+            if i > 0 and curly_count == 0:
+                return code[:i + 1]
+
+
+def find_pragmas(code):
+    for match in PRAGMA_START_RE.finditer(code):
+        yield match.start(0), match_single_pragma(code[match.start(0):])
+
+
+def lint_pragma(pragma):
+    if 'pytmc' not in pragma:
+        return
+
+    pragma = pragma.strip()
+    match = PRAGMA_RE.match(pragma)
+    if not match:
+        raise LinterError()
+    return match
+
+
+def _build_map_of_offset_to_line_number(source):
+    start_index = 0
+    index_to_line_number = {}
+    # A slow and bad algorithm, but only to be used in parsing declarations
+    # which are rather small
+    for line_number, line in enumerate(source.splitlines(), 1):
+        for index in range(start_index, start_index + len(line) + 1):
+            index_to_line_number[index] = line_number
+        start_index += len(line) + 1
+    return index_to_line_number
+
+
+def lint_source(filename, source, verbose=False):
+    heading_shown = False
+
+    for decl in source.find(parser.Declaration):
+        if not decl.text.strip():
+            continue
+
+        offset_to_line_number = _build_map_of_offset_to_line_number(decl.text)
+
+        parent = decl.parent
+        path_to_source = []
+        while parent is not source:
+            if parent.name is not None:
+                path_to_source.insert(0, parent.name)
+            parent = parent.parent
+
+        pragmas = list(find_pragmas(decl.text))
+        if not pragmas:
+            continue
+
+        if verbose:
+            if not heading_shown:
+                print()
+                util.sub_heading(f'{filename} ({source.tag})')
+                heading_shown = True
+
+            util.sub_sub_heading(
+                f'{".".join(path_to_source)}: {decl.tag} - '
+                f'{len(pragmas)} pragmas'
+            )
+
+        for offset, pragma in pragmas:
+            try:
+                lint_pragma(pragma)
+            except LinterError as ex:
+                ex.tag = source.tag
+                ex.filename = filename
+                ex.pragma = pragma
+                ex.line_number = offset_to_line_number[offset]
+                yield pragma, ex
+            else:
+                yield pragma, None
+
+
+def main(filename, use_markdown=False, verbose=False):
+    proj_path = pathlib.Path(filename)
+    # if proj_path.suffix.lower() not in ('.tsproj', ):
+    #     raise ValueError('Expected a .tsproj file')
+
+    project = parser.parse(proj_path)
+    pragma_count = 0
+    linter_errors = 0
+
+    if hasattr(project, 'plcs'):
+        for i, plc in enumerate(project.plcs, 1):
+            util.heading(f'PLC Project ({i}): {plc.project_path.stem}')
+            for fn, source in plc.source.items():
+                for pragma, ex in lint_source(fn, source, verbose=verbose):
+                    pragma_count += 1
+                    if ex is not None:
+                        linter_errors += 1
+                        logger.error('Linter error: %s\n%s:line %s: %s',
+                                     ex, fn, ex.line_number,
+                                     textwrap.indent(ex.pragma, '    '))
+    else:
+        source = project
+        for pragma, ex in lint_source(filename, source, verbose=verbose):
+            pragma_count += 1
+            if ex is not None:
+                linter_errors += 1
+                logger.error('Linter error: %s\n%s:line %s: %s',
+                             ex, filename, ex.line_number,
+                             textwrap.indent(ex.pragma, '    '))
+
+    logger.info('Total pragmas found: %d Total linter errors: %d',
+                pragma_count, linter_errors)
+
+    if linter_errors > 0:
+        sys.exit(1)

--- a/pytmc/bin/pragmalint.py
+++ b/pytmc/bin/pragmalint.py
@@ -14,7 +14,7 @@ import textwrap
 from .. import parser
 from . import util
 from .db import LinterError
-from ..pragmas import _FLEX_TERM_END
+
 
 DESCRIPTION = __doc__
 logger = logging.getLogger(__name__)
@@ -24,9 +24,8 @@ PRAGMA_RE = re.compile(
     r"^{\s*attribute[ \t]+'pytmc'[ \t]*:=[ \t]*'(?P<setting>[\s\S]*)'}$",
     re.MULTILINE
 )
-PRAGMA_LINE_RE = re.compile(
-    r"([^\r\n$;]*)", re.MULTILINE)
-PRAGMA_SETTING_RE =re.compile(
+PRAGMA_LINE_RE = re.compile(r"([^\r\n$;]*)", re.MULTILINE)
+PRAGMA_SETTING_RE = re.compile(
     r"\s*(?P<title>[a-zA-Z0-9]+)\s*:\s*(?P<setting>.*?)\s*$")
 PRAGMA_PV_LINE_RE = re.compile(r"pv\s*:")
 
@@ -115,10 +114,10 @@ def lint_pragma(pragma):
     # There shall be at one config line at minimum
     if config_lines_detected <= 0:
         raise LinterError("No configuration line(s) detected in a pragma.")
-    
+
     # There shall be a config line for pv even if it's just "pv:"
     if pv_line_detected <= 0:
-        raise LinterError("No pv line(s) detected in a pragma") 
+        raise LinterError("No pv line(s) detected in a pragma")
 
     return match
 
@@ -152,8 +151,8 @@ def lint_source(filename, source, verbose=False):
         filename argument
 
     verbose : bool
-        Show more context around the linting process, including all source file names and
-        number of pragmas found
+        Show more context around the linting process, including all source file
+        names and number of pragmas found
     '''
     heading_shown = False
     for decl in source.find(parser.Declaration):

--- a/pytmc/bin/pragmalint.py
+++ b/pytmc/bin/pragmalint.py
@@ -53,6 +53,10 @@ def build_arg_parser(argparser=None):
 
 
 def match_single_pragma(code):
+    '''
+    Given a block of code starting at a pragma, return the pragma up to its
+    closing curly brace.
+    '''
     curly_count = 0
     for i, char in enumerate(code):
         if char == '{':
@@ -69,6 +73,9 @@ def find_pragmas(code):
 
 
 def lint_pragma(pragma):
+    '''
+    Lint a pragma against the PRAGMA_RE regular expression. Raises LinterError
+    '''
     if 'pytmc' not in pragma:
         return
 
@@ -80,6 +87,9 @@ def lint_pragma(pragma):
 
 
 def _build_map_of_offset_to_line_number(source):
+    '''
+    For a multiline source file, return {character_pos: line}
+    '''
     start_index = 0
     index_to_line_number = {}
     # A slow and bad algorithm, but only to be used in parsing declarations
@@ -92,6 +102,9 @@ def _build_map_of_offset_to_line_number(source):
 
 
 def lint_source(filename, source, verbose=False):
+    '''
+    Lint `filename` given TwincatItem `source`.
+    '''
     heading_shown = False
 
     for decl in source.find(parser.Declaration):
@@ -137,9 +150,6 @@ def lint_source(filename, source, verbose=False):
 
 def main(filename, use_markdown=False, verbose=False):
     proj_path = pathlib.Path(filename)
-    # if proj_path.suffix.lower() not in ('.tsproj', ):
-    #     raise ValueError('Expected a .tsproj file')
-
     project = parser.parse(proj_path)
     pragma_count = 0
     linter_errors = 0

--- a/pytmc/bin/pytmc.py
+++ b/pytmc/bin/pytmc.py
@@ -14,7 +14,7 @@ DESCRIPTION = __doc__
 
 
 MODULES = ('summary', 'stcmd', 'db', 'xmltranslate', 'debug', 'types',
-           'iocboot')
+           'iocboot', 'pragmalint')
 
 
 def _try_import(module):

--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -113,36 +113,9 @@ def main(tsproj_project, use_markdown=False, show_all=False,
 
     project = parser.parse(proj_path)
 
-    def heading(text):
-        print(text)
-        print('=' * len(text))
-        print()
-
-    def sub_heading(text):
-        print(text)
-        print('-' * len(text))
-        print()
-
-    def sub_sub_heading(text, level=3):
-        if use_markdown:
-            print('#' * level, text)
-        else:
-            print(' ' * level, '-', text)
-        print()
-
-    def text_block(text, indent=4, language='vhdl'):
-        if use_markdown:
-            print(f'```{language}')
-            print(text)
-            print(f'```')
-        else:
-            for line in text.splitlines():
-                print(' ' * indent, line)
-        print()
-
     if show_plcs or show_all:
         for i, plc in enumerate(project.plcs, 1):
-            heading(f'PLC Project ({i}): {plc.project_path.stem}')
+            util.heading(f'PLC Project ({i}): {plc.project_path.stem}')
             print(f'    Project path: {plc.project_path}')
             print(f'    TMC path:     {plc.tmc_path}')
             print(f'    AMS ID:       {plc.ams_id}')
@@ -163,7 +136,7 @@ def main(tsproj_project, use_markdown=False, show_all=False,
 
             if show_code:
                 for fn, source in plc.source.items():
-                    sub_heading(f'{fn} ({source.tag})')
+                    util.sub_heading(f'{fn} ({source.tag})')
                     for decl_or_impl in source.find((parser.ST,
                                                      parser.Declaration,
                                                      parser.Implementation)):
@@ -176,13 +149,18 @@ def main(tsproj_project, use_markdown=False, show_all=False,
                             if parent.name is not None:
                                 path_to_source.insert(0, parent.name)
                             parent = parent.parent
-                        sub_sub_heading(f'{".".join(path_to_source)}: '
-                                        f'{decl_or_impl.tag}')
-                        text_block(decl_or_impl.text)
+                        util.sub_sub_heading(
+                            f'{".".join(path_to_source)}: {decl_or_impl.tag}',
+                            use_markdown=use_markdown
+                        )
+                        util.text_block(
+                            decl_or_impl.text,
+                            markdown_language='vhdl' if use_markdown else None
+                        )
                     print()
 
     if show_symbols or show_all:
-        sub_heading('Symbols')
+        util.sub_heading('Symbols')
         symbols = list(project.find(parser.Symbol))
         for symbol in symbols:
             info = symbol.info
@@ -191,13 +169,13 @@ def main(tsproj_project, use_markdown=False, show_all=False,
         print()
 
     if show_boxes or show_all:
-        sub_heading('Boxes')
+        util.sub_heading('Boxes')
         boxes = list(project.find(parser.Box))
         for box in boxes:
             print(f'    {box.attributes["Id"]}.) {box.name}')
 
     if show_nc or show_all:
-        sub_heading('NC axes')
+        util.sub_heading('NC axes')
         ncs = list(project.find(parser.NC))
         for nc in ncs:
             for axis_id, axis in sorted(nc.axis_by_id.items()):
@@ -211,7 +189,7 @@ def main(tsproj_project, use_markdown=False, show_all=False,
                 print()
 
     if show_links or show_all:
-        sub_heading('Links')
+        util.sub_heading('Links')
         links = list(project.find(parser.Link))
         for i, link in enumerate(links, 1):
             print(f'    {i}.) A {link.a}')

--- a/pytmc/bin/util.py
+++ b/pytmc/bin/util.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytmc
 from pytmc.parser import TwincatItem, TWINCAT_TYPES
 
@@ -22,3 +24,34 @@ def python_debug_session(namespace, message):
         pdb.set_trace()
     else:
         embed()
+
+
+def heading(text, *, file=sys.stdout):
+    print(text, file=file)
+    print('=' * len(text), file=file)
+    print(file=file)
+
+
+def sub_heading(text, *, file=sys.stdout):
+    print(text, file=file)
+    print('-' * len(text), file=file)
+    print(file=file)
+
+
+def sub_sub_heading(text, level=3, *, use_markdown=False, file=sys.stdout):
+    if use_markdown:
+        print('#' * level, text, file=file)
+    else:
+        print(' ' * level, '-', text, file=file)
+    print(file=file)
+
+
+def text_block(text, indent=4, markdown_language=None, *, file=sys.stdout):
+    if markdown_language is not None:
+        print(f'```{markdown_language}', file=file)
+        print(text, file=file)
+        print(f'```', file=file)
+    else:
+        for line in text.splitlines():
+            print(' ' * indent, line, file=file)
+    print(file=file)

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 # Select special delimiter sequences and prepare them for re injection
-_FLEX_TERM_REGEX = "|".join([r";", r";;", r"[\n\r]", r"$"])
+_FLEX_TERM_END = [r";", r";;", r"[\n\r]", r"$"]
+_FLEX_TERM_REGEX = "|".join(_FLEX_TERM_END)
 
 # Break configuration str into list of lines paired w/ their delimiters
 _LINE_FINDER = re.compile(r"(?P<line>.+?)(?P<delim>" + _FLEX_TERM_REGEX + ")")

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -4,6 +4,7 @@ import sys
 import pytmc.bin.pytmc as pytmc_main
 from pytmc.bin.db import main as db_main
 from pytmc.bin.debug import create_debug_gui
+from pytmc.bin.pragmalint import main as pragmalint_main
 from pytmc.bin.stcmd import main as stcmd_main
 from pytmc.bin.summary import main as summary_main
 from pytmc.bin.types import create_types_gui
@@ -27,6 +28,10 @@ def test_help_module(monkeypatch, subcommand):
 def test_summary(project_filename):
     summary_main(project_filename, show_all=True, show_code=True,
                  use_markdown=True)
+
+
+def test_pragmalint(project_filename):
+    pragmalint_main(project_filename, verbose=True, use_markdown=True)
 
 
 def test_stcmd(project_filename):

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -35,7 +35,10 @@ def test_pragmalint(project_filename):
 
 
 def test_stcmd(project_filename):
-    stcmd_main(project_filename)
+    kwargs = (dict(plc_name='plc_kfe_xgmd_vac')
+              if 'plc_kfe_xgmd_vac' in project_filename
+              else {})
+    stcmd_main(project_filename, **kwargs)
 
 
 def test_xmltranslate(project_filename):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -24,7 +24,7 @@ def test_summarize(project):
 
 def test_module_ads_port(project):
     for inst in project.find(parser.Module):
-        assert inst.ads_port == 851  # probably!
+        assert inst.ads_port == 851 or inst.ads_port == 852  # probably!
 
 
 @pytest.mark.xfail(reason='TODO / project')


### PR DESCRIPTION
Pragmas in TwinCAT are syntactically strange and difficult to type, and TwinCAT is rather specific about what it's looking for - silently ignoring the pragma altogether if it doesn't match up.

So, the idea here is to give a tool to lint the project to find pragma errors before they get further down the line.

I'm not 100% sure about the regex given here, but it at least caught some problematic ones in my local tests.

Example:

```
$ pytmc pragmalint ~/Repos/L2SI-Vacuum-Lib/L2SIVacuumLib.tsproj 
PLC Project (1): L2SIVacuum
===========================

ERROR:pytmc.bin.pragmalint:Linter error:
DUTs/Valves/ST_VGC.TcDUT:line 54:     {attribute 'pytmc' :=
        'pv: Ext_ILK_OK ;
        field: ZNAM NOT OK ;
        field: ONAM OK ;
        io: i ;
    '}
ERROR:pytmc.bin.pragmalint:Linter error:
DUTs/Valves/ST_VGC.TcDUT:line 134:     {attribute 'pytmc' :=
        'pv: POS_STATE ;
        type: mbbi ;
        field: ZRST OPEN ;
        field: ONST CLOSED ;
        field: TWST MOVING ;
        field: THST INVALID ;
        io: i
        '}
ERROR:pytmc.bin.pragmalint:Linter error:
POUs/Functions/Gauges/FB_MKS_937B.TcPOU:line 13:     {attribute 'pytmc' := pv: '}
```