### PR TITLE
ENH: replace underscores in plc names with dashes in ioc name

### DIFF
--- a/pytmc/bin/iocboot.py
+++ b/pytmc/bin/iocboot.py
@@ -100,7 +100,8 @@ def main(tsproj_project, ioc_template_path, *, prefix='ioc-', debug=False,
         if plcs is not None and plc_name not in plcs:
             continue
 
-        ioc_path = pathlib.Path(f'{prefix}{plc_name}').absolute()
+        ioc_name = plc_name.replace('_', '-')
+        ioc_path = pathlib.Path(f'{prefix}{ioc_name}').absolute()
         if not dry_run:
             os.makedirs(ioc_path, exist_ok=True)
         makefile_path = ioc_path / 'Makefile'


### PR DESCRIPTION
The IOC naming convention has dashes, e.g. `ioc-fee-motion`, but these are not allowed in the plc project names because TwinCAT forbids it.

The idea is that we use underscores instead in the plc name and convert them to dashes in the ioc name. This was discussed at some point but never made it into the library here.