### PR TITLE
FIX: make T_MaxString:=STRING(255)

### DIFF
--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -572,6 +572,8 @@ class DataTypes(_TmcItem):
             for dtype in self.find(DataType)
         }
 
+        self.types['Tc2_System.T_MaxString'] = T_MaxString()
+
 
 class Type(_TmcItem):
     '[TMC] DataTypes/DataType/SubItem/Type'
@@ -813,6 +815,11 @@ class BuiltinDataType:
 
     def walk(self, condition=None):
         yield []
+
+
+class T_MaxString(BuiltinDataType):
+    def __init__(self):
+        super().__init__(typename='STRING', length=255)
 
 
 class Symbol(_TmcItem):


### PR DESCRIPTION
pytmc expanded the T_MaxString to a basic data type, which did not have a pytmc pragma and was therefore ignored. This could be considered a workaround (or, ahem, hack). Confirmed working with the PMPS library.

Fancy "typedefs" such as this may trip us up again in the future and perhaps require a bit more thought.