### PR TITLE
FIX: enums; utf8 BOM on win32

### DIFF
--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -34,7 +34,7 @@ def parse(fn, *, parent=None):
     '''
     fn = case_insensitive_path(fn)
 
-    with open(fn, 'rt', encoding='utf-8') as f:
+    with open(fn, 'rb') as f:
         tree = lxml.etree.parse(f)
 
     root = tree.getroot()

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -673,11 +673,8 @@ class DataType(_TmcItem):
 
         if hasattr(self, 'SubItem'):
             for subitem in self.SubItem:
-                if condition and not condition(subitem):
-                    continue
-                for item in subitem.walk():
-                    if condition is None or all(condition(it) for it in item):
-                        yield [subitem] + item
+                for item in subitem.walk(condition=condition):
+                    yield [subitem] + item
 
     @property
     def enum_dict(self):
@@ -737,7 +734,8 @@ class SubItem(_TmcItem):
         return f'{namespace}.{type_.text}' if namespace else type_.text
 
     def walk(self, condition=None):
-        yield from self.data_type.walk(condition=condition)
+        if condition is None or condition(self):
+            yield from self.data_type.walk(condition=condition)
 
 
 class Module(_TmcItem):
@@ -878,8 +876,7 @@ class Symbol(_TmcItem):
     def walk(self, condition=None):
         if condition is None or condition(self):
             for item in self.data_type.walk(condition=condition):
-                if condition is None or all(condition(it) for it in item):
-                    yield [self] + item
+                yield [self] + item
 
     @property
     def array_info(self):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -63,7 +63,9 @@ def projects_from_solution(fn, *, exclude=None):
         for match in SLN_PROJECT_RE.findall(solution_text)
     ]
 
-    return [pathlib.Path(project) for project in projects
+    solution_path = pathlib.Path(fn).parent
+    return [(solution_path / pathlib.Path(project)).absolute()
+            for project in projects
             if project.suffix not in exclude
             ]
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -655,6 +655,13 @@ class DataType(_TmcItem):
         return True
 
     def walk(self, condition=None):
+        if self.is_enum:
+            # Ensure something is yielded for this type - it doesn't
+            # appear possible to have SubItems or use ExtendsType
+            # in this case.
+            yield []
+            return
+
         extends_types = [
             self.tmc.get_data_type(ext_type.qualified_type)
             for ext_type in getattr(self, 'ExtendsType', [])
@@ -867,9 +874,10 @@ class Symbol(_TmcItem):
                     )
 
     def walk(self, condition=None):
-        for item in self.data_type.walk(condition=condition):
-            if condition is None or all(condition(it) for it in item):
-                yield [self] + item
+        if condition is None or condition(self):
+            for item in self.data_type.walk(condition=condition):
+                if condition is None or all(condition(it) for it in item):
+                    yield [self] + item
 
     @property
     def array_info(self):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -34,7 +34,7 @@ def parse(fn, *, parent=None):
     '''
     fn = case_insensitive_path(fn)
 
-    with open(fn, 'rt') as f:
+    with open(fn, 'rt', encoding='utf-8') as f:
         tree = lxml.etree.parse(f)
 
     root = tree.getroot()


### PR DESCRIPTION
The UTF-8 BOM was causing pytmc running on Windows to bail immediately with the message:
```
lxml.etree.XMLSyntaxError: Start tag expected, '<' not found, line 1, column 1
```

Enums were apparently also being ignored in some (all?) cases in recent builds. b79f4a9 attempts to fix that by ensuring `DataType.walk()` is always yielding something, allowing for the creation of chains.

Confusing implementation detail: enums should be seen to pytmc in a way similar to a built-in type (UINT + some metadata), and as `BuiltInType` yields `[]` for `walk()` this PR brings it in line with that.

~One test is now failing as a previously-ignored enum is now found to be duplicated...~ The pragma was already fixed upstream; updated to master in 53aa27f.