### PR TITLE
REF: sort record fields

### DIFF
--- a/pytmc/templates/asyn_standard_record.jinja2
+++ b/pytmc/templates/asyn_standard_record.jinja2
@@ -1,6 +1,6 @@
 record({{record.record_type}}, "{{record.pvname}}"){
 {% block add_fields  %}{% endblock %}
-{% for f in record.fields%}
+{% for f in record.fields|sort%}
   field({{f}}, "{{record.fields[f]}}")
 {% endfor %}
 }


### PR DESCRIPTION
_This doesn't have to be merged_ - but we should decide sooner rather than later if we are going this route.

Closes #109 

Pluses:
- Output is always consistent
- Better diffs

Minus:
- Fields you'd expect to be grouped might no longer be grouped (`ZNAM` and `ONAM`, or some of the ugly mbbi/mbbo ones for 1-15)

If we think the plus outweighs the minus, then let's go with it. If not, we can close this.

Example before:
```sh
record(mbbi, "MR1K4_GCC_1:STATE_RBV"){
  field(PINI, "1")
  field(TSE, "-2")
  field(ZRVL, "1")
  field(ZRST, "PressInvalid")
  field(ONVL, "2")
  field(ONST, "GaugeDisconnected")
  field(TWVL, "3")
  field(TWST, "Off")
  field(THVL, "4")
  field(THST, "Starting")
  field(FRVL, "6")
  field(FRST, "OoR")
  field(FVVL, "10")
  field(FVST, "Valid")
  field(SXVL, "11")
  field(SXST, "ValidHi")
  field(SVVL, "12")
  field(SVST, "ValidLo")
  field(INP, "@asyn($(PORT),0,1)ADSPORT=851/GVL_DEVICES.MR1K4_GCC_1.IG.eState?")
  field(DTYP, "asynInt32")
  field(SCAN, "I/O Intr")
}
```

After:
```sh
record(mbbi, "MR1K4_GCC_1:STATE_RBV"){
  field(DTYP, "asynInt32")
  field(FRST, "OoR")
  field(FRVL, "6")
  field(FVST, "Valid")
  field(FVVL, "10")
  field(INP, "@asyn($(PORT),0,1)ADSPORT=851/GVL_DEVICES.MR1K4_GCC_1.IG.eState?")
  field(ONST, "GaugeDisconnected")
  field(ONVL, "2")
  field(PINI, "1")
  field(SCAN, "I/O Intr")
  field(SVST, "ValidLo")
  field(SVVL, "12")
  field(SXST, "ValidHi")
  field(SXVL, "11")
  field(THST, "Starting")
  field(THVL, "4")
  field(TSE, "-2")
  field(TWST, "Off")
  field(TWVL, "3")
  field(ZRST, "PressInvalid")
  field(ZRVL, "1")
}
```