### PR TITLE
ENH: add autosave support

### DIFF
--- a/docs/pragma_usage.rst
+++ b/docs/pragma_usage.rst
@@ -277,3 +277,48 @@ Valid options for this field are:
    ".5 second"
    ".2 second"
    ".1 second"
+
+
+Autosave
+''''''''
+
+Autosave fields for individual EPICS records are configured by default with
+pytmc. It is possible to customize this behavior with additional pragmas,
+optionally specifying different fields for input or output records.
+
+Pass 0 indicates restoring information prior to record initialization on IOC
+initialization, whereas pass 1 indicates restoring information after record
+initialization. Pass 0 is generally safe and does not cause record processing,
+whereas pass 1 is just as if one were to ``caput`` to the record after starting
+the IOC. When in doubt, use pass 0 and/or ask an EPICS expert.
+
+To apply to either input or output records, pragma keys ``autosave_pass0`` or
+``autosave_pass1`` can be used.
+
+To only apply to input records, pragma keys ``autosave_input_pass0``
+``autosave_input_pass1`` can be used.
+
+To only apply to output records, pragma keys ``autosave_output_pass0``
+``autosave_output_pass1`` can be used.
+
+For example, a pragma like the following:
+
+.. code-block:: none
+   
+   autosave_pass0: VAL DESC
+
+
+Would result in both input and output records having these fields marked for
+autosaving:
+
+.. code-block:: none
+
+   record(ai, "my:record_RBV") {
+      ...
+      info(autosave_pass0, "VAL DESC")
+   }
+
+   record(ao, "my:record") {
+      ...
+      info(autosave_pass0, "VAL DESC")
+   }

--- a/pytmc/templates/asyn_standard_record.jinja2
+++ b/pytmc/templates/asyn_standard_record.jinja2
@@ -1,6 +1,11 @@
-record({{record.record_type}}, "{{record.pvname}}"){
+record({{record.record_type}}, "{{record.pvname}}") {
 {% block add_fields  %}{% endblock %}
 {% for f in record.fields%}
   field({{f}}, "{{record.fields[f]}}")
+{% endfor %}
+{% for autosave_pass in ['pass0', 'pass1'] %}
+    {% if record.autosave[autosave_pass] %}
+  info(autosave_{{autosave_pass}}, "{{ record.autosave[autosave_pass] | join(' ') }}")
+    {% endif %}
 {% endfor %}
 }

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -8,7 +8,9 @@ def test_epics_record_render():
     kwargs = {'pvname': 'Tst:pv',
               'record_type': 'ai',
               'fields': {'ZNAM': 'Out',
-                         'ONAM': 'In'}}
+                         'ONAM': 'In'},
+              'direction': 'input',
+              }
 
     ec = EPICSRecord(**kwargs)
     record = ec.render()
@@ -25,7 +27,9 @@ def test_epics_record_with_linter(dbd_file):
               'record_type': 'bi',
               'fields': {'ZNAM': '"Out"',
                          'ONAM': '"In"',
-                         'DTYP': '"Raw Soft Channel"'}}
+                         'DTYP': '"Raw Soft Channel"'},
+              'direction': 'input',
+              }
     ec = EPICSRecord(**kwargs)
     record = ec.render()
     linted = lint_db(dbd=dbd_file, db=record)


### PR DESCRIPTION
Closes #41 

Defaults are specified in classes from `pytmc.record`. These can be overridden by using specific keys in the pragmas:

```
        To apply to either input or output records, pragma keys `autosave_pass0`
        or `autosave_pass1` can be used.

        To only apply to input records, pragma keys `autosave_input_pass0`
        `autosave_input_pass1` can be used.

        To only apply to output records, pragma keys `autosave_output_pass0`
        `autosave_output_pass1` can be used.
```

More info in the documentation commit (see diff).

I have not given the defaults much thought, but with this PR as a basis we can fill in those details later.