### PR TITLE
MNT: show summary paths relative to the project root

### DIFF
--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -108,6 +108,8 @@ def summary(tsproj_project, use_markdown=False, show_all=False,
             show_links=False, log_level=None, debug=False):
 
     proj_path = pathlib.Path(tsproj_project)
+    proj_root = proj_path.parent.resolve().absolute()
+
     if proj_path.suffix.lower() not in ('.tsproj', ):
         raise ValueError('Expected a .tsproj file')
 
@@ -116,16 +118,21 @@ def summary(tsproj_project, use_markdown=False, show_all=False,
     if show_plcs or show_all or show_code or show_symbols:
         for i, plc in enumerate(project.plcs, 1):
             util.heading(f'PLC Project ({i}): {plc.project_path.stem}')
-            print(f'    Project path: {plc.project_path}')
-            print(f'    TMC path:     {plc.tmc_path}')
+            print(f'    Project root: {proj_root}')
+            print(f'    Project path:',
+                  plc.project_path.resolve().relative_to(proj_root))
+            print(f'    TMC path:    ',
+                  plc.tmc_path.resolve().relative_to(proj_root))
             print(f'    AMS ID:       {plc.ams_id}')
             print(f'    IP Address:   {plc.target_ip} (* based on AMS ID)')
             print(f'    Port:         {plc.port}')
             print(f'')
-            proj_info = [('Source files', plc.source_filenames),
-                         ('POUs', plc.pou_by_name),
-                         ('GVLs', plc.gvl_by_name),
-                         ]
+            proj_info = [
+                ('Source files', [pathlib.Path(fn).relative_to(proj_root)
+                                  for fn in plc.source_filenames]),
+                ('POUs', plc.pou_by_name),
+                ('GVLs', plc.gvl_by_name),
+            ]
 
             for category, items in proj_info:
                 if items:


### PR DESCRIPTION
Just for readability. See example below.

Before:
```
$ pytmc summary ../lcls-twincat-general/LCLSGeneral/LCLSGeneral.tsproj  --plcs
PLC Project (1): LCLSGeneral
============================

    Project path: /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
    TMC path:     /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/LCLSGeneral.tmc
    AMS ID:
    IP Address:    (* based on AMS ID)
    Port:         851

    Source files:
        1.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/Data types/Misc/ST_EcDevice.TcDUT
        2.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/Data types/Misc/ST_FbDiagnostics.TcDUT
        3.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/Data types/Misc/ST_System.TcDUT
        4.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/GVLs/DefaultGlobals.TcGVL
        5.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_EcatDiag.TcPOU
        6.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_Index.TcPOU
        7.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_XKoyoPLCModbus.TcPOU
        8.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
        9.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
        10.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
        11.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/DUTs/E_MesgSevr.TcDUT
        12.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/DUTs/E_MessengerState.TcDUT
        13.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/DUTs/E_Subsystem.TcDUT
        14.) /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral/LCLSGeneral/POUs/Logger/SYSTEM_TIME_TO_RFC3339.TcPOU

    GVLs:
        1.) DefaultGlobals
        2.) GVL_Logger
```

After:
```
(pytmc) klauer-osx:pytmc klauer$ pytmc summary ../lcls-twincat-general/LCLSGeneral/LCLSGeneral.tsproj  --plcs
PLC Project (1): LCLSGeneral
============================

    Project root: /Users/klauer/docs/Repos/lcls-twincat-general/LCLSGeneral
    Project path: LCLSGeneral/LCLSGeneral.plcproj
    TMC path:     LCLSGeneral/LCLSGeneral.tmc
    AMS ID:
    IP Address:    (* based on AMS ID)
    Port:         851

    Source files:
        1.) LCLSGeneral/Data types/Misc/ST_EcDevice.TcDUT
        2.) LCLSGeneral/Data types/Misc/ST_FbDiagnostics.TcDUT
        3.) LCLSGeneral/Data types/Misc/ST_System.TcDUT
        4.) LCLSGeneral/GVLs/DefaultGlobals.TcGVL
        5.) LCLSGeneral/POUs/Functions/FB_EcatDiag.TcPOU
        6.) LCLSGeneral/POUs/Functions/FB_Index.TcPOU
        7.) LCLSGeneral/POUs/Functions/FB_XKoyoPLCModbus.TcPOU
        8.) LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
        9.) LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
        10.) LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
        11.) LCLSGeneral/POUs/Logger/DUTs/E_MesgSevr.TcDUT
        12.) LCLSGeneral/POUs/Logger/DUTs/E_MessengerState.TcDUT
        13.) LCLSGeneral/POUs/Logger/DUTs/E_Subsystem.TcDUT
        14.) LCLSGeneral/POUs/Logger/SYSTEM_TIME_TO_RFC3339.TcPOU

    GVLs:
        1.) DefaultGlobals
        2.) GVL_Logger

```