### PR TITLE
DIST: fix requirements + manifest for pypi installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include versioneer.py
+include requirements.txt
+include README.rst
+include pytmc/templates/*
 include pytmc/_version.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Jinja2
 lxml
-git+https://github.com/epicsdeb/pypdb.git
+epics-pypdb

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
+requirements = open(path.join(here, 'requirements.txt')).read().splitlines()
 
 setup(
     name     = 'pytmc',
@@ -46,4 +47,6 @@ setup(
       'pytmc': ['templates/*'],
     },
     include_package_data=True,
+    python_requires='>=3.6',
+    install_requires=requirements,
 )


### PR DESCRIPTION
Closes #59 🎆 

1. Made our own release of pyPDB to pypi - https://pypi.org/project/epics-pypdb/  - had to rename due to a package naming conflict
2. Fixed manifest + install requirements
3. Released the latest version to pypi - https://pypi.org/project/pytmc/

`pip install pytmc` _should_ work now...