### PR TITLE
Enh: show incomplete pragmas

### DIFF
--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -74,7 +74,7 @@ def validate_with_dbd(packages, dbd_file, remove_invalid_fields=True,
 
 
 def process(tmc, *, dbd_file=None, allow_errors=False,
-            show_error_context=True):
+            show_error_context=True, allow_no_pragma=False):
     '''
     Process a TMC
 
@@ -104,9 +104,10 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
 
     records = [
         record
-        for symbol in find_pytmc_symbols(tmc)
+        for symbol in find_pytmc_symbols(tmc, allow_no_pragma=allow_no_pragma)
         for record in record_packages_from_symbol(symbol,
-                                                  yield_exceptions=True)
+                                                  yield_exceptions=True,
+                                                  allow_no_pragma=allow_no_pragma)
     ]
 
     exceptions = [ex for ex in records

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -120,7 +120,10 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
     if exceptions and not allow_errors:
         raise LinterError('Failed to create database')
 
-    record_names = [record.pvname for record in records]
+    if allow_no_pragma:
+        record_names = [record.pvname for record in records if record.valid]
+    else:
+        record_names = [record.pvname for record in records]
     if len(record_names) != len(set(record_names)):
         dupes = {name: record_names.count(name)
                  for name in record_names

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -112,6 +112,8 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
 
     exceptions = [ex for ex in records
                   if isinstance(ex, Exception)]
+    # It looks like exceptions are still getting returned because I'm tripping
+    # the following statement:
     for ex in exceptions:
         logger.error('Error creating record: %s', ex)
         records.remove(ex)

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -112,7 +112,7 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
 
     exceptions = [ex for ex in records
                   if isinstance(ex, Exception)]
-    
+
     for ex in exceptions:
         logger.error('Error creating record: %s', ex)
         records.remove(ex)

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -112,8 +112,7 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
 
     exceptions = [ex for ex in records
                   if isinstance(ex, Exception)]
-    # It looks like exceptions are still getting returned because I'm tripping
-    # the following statement:
+    
     for ex in exceptions:
         logger.error('Error creating record: %s', ex)
         records.remove(ex)

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -105,9 +105,8 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
     records = [
         record
         for symbol in find_pytmc_symbols(tmc, allow_no_pragma=allow_no_pragma)
-        for record in record_packages_from_symbol(symbol,
-                                                  yield_exceptions=True,
-                                                  allow_no_pragma=allow_no_pragma)
+        for record in record_packages_from_symbol(
+            symbol, yield_exceptions=True, allow_no_pragma=allow_no_pragma)
     ]
 
     exceptions = [ex for ex in records

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -218,14 +218,6 @@ class TmcSummary(QtWidgets.QMainWindow):
                 key = str(key)
                 if key not in columns:
                     columns[key] = max(columns.values()) + 1 if columns else 0
-                print("row:")
-                print(row)
-                print("key:")
-                print(key)
-                print("columns[key]")
-                print(columns[key])
-                print("value:")
-                print(value)
                 # accumulate a list of entries to print in the chart. These
                 # should only be printed after `setColumnCount` has been run
                 if isinstance(value, dict):
@@ -241,8 +233,6 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         items = zip(chain.config['pv'], chain.item_to_config.items())
         for row, (pv, (item, config)) in enumerate(items):
-            print("config:***************")
-            print(config)
             # info_dict is a collection of the non-field pragma lines
             info_dict = dict(pv=pv)
             if config is not None:
@@ -252,22 +242,21 @@ class TmcSummary(QtWidgets.QMainWindow):
                 column_write_entries.extend(new_entries)
                 # fields is a dictionary exclusively contining fields
                 fields = config.get('field', {})
-                print("fields:")
-                print(fields)
-                new_entries = add_dict_to_table(row, {f'field_{k}': v
-                                        for k, v in fields.items()
-                                        if k != 'field'}
-                                  )
+                new_entries = add_dict_to_table(
+                    row, {
+                        f'field_{k}': v
+                        for k, v in fields.items()
+                        if k != 'field'
+                    }
+                )
                 column_write_entries.extend(new_entries)
 
         # setColumnCount seems to need to proceed the setHorizontalHeaderLabels
         # in order to prevent QT from incorrectly drawing/labeling the cols
         self.config_info.setColumnCount(len(columns))
         self.config_info.setHorizontalHeaderLabels(list(columns))
-        # finally print the column's entries 
-        print(column_write_entries)
+        # finally print the column's entries
         for line in column_write_entries:
-            print(line)
             if line:
                 self.config_info.setItem(*line)
 

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -94,7 +94,7 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.records = {}
 
         records, self.exceptions = process(tmc, allow_errors=True,
-            allow_no_pragma=True)
+                                           allow_no_pragma=True)
 
         for record in records:
             if not record.valid:
@@ -112,7 +112,7 @@ class TmcSummary(QtWidgets.QMainWindow):
                 try:
                     record_text
                 except NameError:
-                    record_text = "Record not rendered" 
+                    record_text = "Record not rendered"
 
                 record_text = (
                     f'!! Linter failure: {ex.__class__.__name__} {ex}'
@@ -208,7 +208,7 @@ class TmcSummary(QtWidgets.QMainWindow):
             """
             Parameters
             ----------
-            row : int 
+            row : int
                 Identify the row to configure.
 
             d : dict
@@ -228,20 +228,21 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         items = zip(chain.config['pv'], chain.item_to_config.items())
         for row, (pv, (item, config)) in enumerate(items):
-            # info_dict is a collection of the non-field pragma lines 
+            # info_dict is a collection of the non-field pragma lines
             info_dict = dict(pv=pv)
             if config is not None:
-                info_dict.update({k: v for k, v in config.items() if k != 'field'})
+                info_dict.update(
+                    {k: v for k, v in config.items() if k != 'field'})
                 add_dict_to_table(row, info_dict)
                 # fields is a dictionary exclusively contining fields
                 fields = config.get('field', {})
                 add_dict_to_table(row, {f'field_{k}': v
-                                    for k, v in fields.items()
-                                    if k != 'field'}
-                              )
-        
+                                        for k, v in fields.items()
+                                        if k != 'field'}
+                                  )
+
         # setColumnCount seems to need to proceed the setHorizontalHeaderLabels
-        # in order to prevent QT from incorrectly drawing/labeling the cols 
+        # in order to prevent QT from incorrectly drawing/labeling the cols
         self.config_info.setColumnCount(len(columns))
         self.config_info.setHorizontalHeaderLabels(list(columns))
         self.config_info.setVerticalHeaderLabels(

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -92,7 +92,10 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.chains = {}
         self.records = {}
 
-        records, self.exceptions = process(tmc, allow_errors=True)
+        records, self.exceptions = process(tmc, allow_errors=True,
+            allow_no_pragma=True)
+        print(records)
+
         for record in records:
             self.chains[record.tcname] = record
             try:

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -245,10 +245,7 @@ class TmcSummary(QtWidgets.QMainWindow):
             if config is not None:
                 info_dict.update({k: v for k, v in config.items() if k != 'field'})
                 add_dict_to_table(row, info_dict)
-            print("info_dict")
-            print(info_dict)
-            # fields is a dictionary exclusively contining fields
-            if config is not None:
+                # fields is a dictionary exclusively contining fields
                 fields = config.get('field', {})
                 add_dict_to_table(row, {f'field_{k}': v
                                     for k, v in fields.items()

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -221,7 +221,7 @@ class TmcSummary(QtWidgets.QMainWindow):
                 # accumulate a list of entries to print in the chart. These
                 # should only be printed after `setColumnCount` has been run
                 if isinstance(value, dict):
-                    yield from _update_config_info(row, value)
+                    yield from add_dict_to_table(row, value)
                 else:
                     yield (
                         row, columns[key],

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -97,7 +97,9 @@ class TmcSummary(QtWidgets.QMainWindow):
         
         all_records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=True)
-        
+
+        print(any(x.valid for x in records))
+        print(any(x.valid for x in all_records))
         for record in records:
             self.chains[record.tcname] = record
             try:

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -257,8 +257,7 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.config_info.setHorizontalHeaderLabels(list(columns))
         # finally print the column's entries
         for line in column_write_entries:
-            if line:
-                self.config_info.setItem(*line)
+            self.config_info.setItem(*line)
 
         self.config_info.setVerticalHeaderLabels(
             list(item.name for item in chain.item_to_config))

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -90,17 +90,17 @@ class TmcSummary(QtWidgets.QMainWindow):
         super().__init__()
         self.tmc = tmc
         self.chains = {}
+        self.incomplete_chains = {}
         self.records = {}
 
         records, self.exceptions = process(tmc, allow_errors=True,
-            allow_no_pragma=False)
-        
-        all_records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=True)
 
         for record in records:
-            if record.valid:
-                pass
+            if not record.valid:
+                self.incomplete_chains[record.tcname] = record
+                continue
+
             self.chains[record.tcname] = record
             try:
                 record_text = record.render()
@@ -255,8 +255,7 @@ class TmcSummary(QtWidgets.QMainWindow):
                 for record, db_text in self.records.items()
             ]
         elif self._mode == "chains w/o records":
-            items = self.chains.items()
-            logger.warning("Not Implemented")
+            items = self.incomplete_chains.items()
         else:
             return
         for name, record in sorted(items,

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -92,13 +92,13 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.chains = {}
         self.records = {}
 
-        good_records, self.exceptions = process(tmc, allow_errors=True,
+        records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=False)
         
         all_records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=True)
         
-        for record in good_records:
+        for record in records:
             self.chains[record.tcname] = record
             try:
                 record_text = record.render()

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -109,10 +109,16 @@ class TmcSummary(QtWidgets.QMainWindow):
                 record_text = _annotate_record_text(linter_results,
                                                     record_text)
             except Exception as ex:
+                try:
+                    record_text
+                except NameError:
+                    record_text = "Record not rendered" 
+
                 record_text = (
                     f'!! Linter failure: {ex.__class__.__name__} {ex}'
                     f'\n\n{record_text}'
                 )
+
                 logger.exception('Linter failure')
 
             self.records[record] = record_text
@@ -214,8 +220,13 @@ class TmcSummary(QtWidgets.QMainWindow):
         columns = {}
 
         if self._mode.lower() != "chains w/o records":
+            print("chain type", type(chain))
             items = zip(chain.config['pv'], chain.item_to_config.items())
             for row, (pv, (item, config)) in enumerate(items):
+                print("row", row)
+                print("pv", pv)
+                print("item", item)
+                print("config", config)
                 info_dict = dict(pv=pv)
                 info_dict.update({k: v for k, v in config.items() if k != 'field'})
                 add_dict_to_table(row, info_dict)
@@ -230,8 +241,9 @@ class TmcSummary(QtWidgets.QMainWindow):
             list(item.name for item in chain.item_to_config))
         
         for item in chain.item_to_config:
-            print(item.Properties)
-            print(dir(item.Properties))
+            pass
+            # print(item.Properties)
+            # print(dir(item.Properties))
 
         self.config_info.setColumnCount(
             max(columns.values()) + 1

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -97,10 +97,6 @@ class TmcSummary(QtWidgets.QMainWindow):
         
         all_records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=True)
-        print(any(x.valid for x in records))
-        print(all(x.valid for x in records))
-        print(any(x.valid for x in all_records))
-        print(all(x.valid for x in all_records))
 
         for record in records:
             if record.valid:

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -230,13 +230,7 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         # if self._mode.lower() != "chains w/o records":
         print("chain type", type(chain))
-        items = list(zip(chain.config['pv'], chain.item_to_config.items()))
-        print("chain.item_to_config.items()")
-        print(chain.item_to_config.items())
-        print("chain.config['pv']")
-        print(chain.config)
-        print("items")
-        print(items)
+        items = zip(chain.config['pv'], chain.item_to_config.items())
         for row, (pv, (item, config)) in enumerate(items):
             #print("row", row)
             #print("pv", pv)

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -221,7 +221,7 @@ class TmcSummary(QtWidgets.QMainWindow):
                 # accumulate a list of entries to print in the chart. These
                 # should only be printed after `setColumnCount` has been run
                 if isinstance(value, dict):
-                    yield from (row, value)
+                    yield from _update_config_info(row, value)
                 else:
                     yield (
                         row, columns[key],

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -97,10 +97,14 @@ class TmcSummary(QtWidgets.QMainWindow):
         
         all_records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=True)
-
         print(any(x.valid for x in records))
+        print(all(x.valid for x in records))
         print(any(x.valid for x in all_records))
+        print(all(x.valid for x in all_records))
+
         for record in records:
+            if record.valid:
+                pass
             self.chains[record.tcname] = record
             try:
                 record_text = record.render()

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -122,6 +122,7 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.item_view_type = QtWidgets.QComboBox()
         self.item_view_type.addItem('Chains')
         self.item_view_type.addItem('Records')
+        self.item_view_type.addItem('Chains w/o Records')
         self.item_view_type.currentTextChanged.connect(self._update_view_type)
         self.item_list = QtWidgets.QListWidget()
 
@@ -246,9 +247,10 @@ class TmcSummary(QtWidgets.QMainWindow):
                 (' / '.join(_grep_record_names(db_text)) or 'Unknown', record)
                 for record, db_text in self.records.items()
             ]
+        elif self._mode == "chains w/o records":
+            print("chains w/o records selected")
         else:
             return
-
         for name, record in sorted(items,
                                    key=lambda item: item[0]):
             item = QtWidgets.QListWidgetItem(name)

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -199,8 +199,6 @@ class TmcSummary(QtWidgets.QMainWindow):
 
     def _update_config_info(self, record):
         'Slot - update config information when a new record is selected'
-        #if self._mode.lower() == "chains w/o records":
-        #    return
         chain = record.chain
 
         self.config_info.clear()
@@ -228,20 +226,10 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         columns = {}
 
-        # if self._mode.lower() != "chains w/o records":
-        print("chain type", type(chain))
         items = zip(chain.config['pv'], chain.item_to_config.items())
         for row, (pv, (item, config)) in enumerate(items):
-            #print("row", row)
-            #print("pv", pv)
-            #print("item", item)
-            #print("config", config)
             # info_dict is a collection of the non-field pragma lines 
             info_dict = dict(pv=pv)
-            print("Item")
-            print(item)
-            print("config")
-            print(config)
             if config is not None:
                 info_dict.update({k: v for k, v in config.items() if k != 'field'})
                 add_dict_to_table(row, info_dict)
@@ -251,8 +239,6 @@ class TmcSummary(QtWidgets.QMainWindow):
                                     for k, v in fields.items()
                                     if k != 'field'}
                               )
-            print("fields")
-            print(fields)
         
         # setColumnCount seems to need to proceed the setHorizontalHeaderLabels
         # in order to prevent QT from incorrectly drawing/labeling the cols 
@@ -260,16 +246,6 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.config_info.setHorizontalHeaderLabels(list(columns))
         self.config_info.setVerticalHeaderLabels(
             list(item.name for item in chain.item_to_config))
-        
-        for item in chain.item_to_config:
-            pass
-            # print(item.Properties)
-            # print(dir(item.Properties))
-
-        #self.config_info.setColumnCount(
-        #    max(columns.values()) + 1
-        #    if columns else 0
-        #)
 
     def _update_record_text(self, record):
         'Slot - update record text when a new record is selected'

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -206,7 +206,16 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.config_info.clear()
         self.config_info.setRowCount(len(chain.chain))
 
-        def add_dict_to_table(row, d):
+        def add_dict_to_table(row: int, d: dict):
+            """
+            Parameters
+            ----------
+            row : int 
+                Identify the row to configure.
+
+            d : dict
+                Dictionary of items to enter into the target row.
+            """
             for key, value in d.items():
                 key = str(key)
                 if key not in columns:
@@ -219,24 +228,33 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         columns = {}
 
-        if self._mode.lower() != "chains w/o records":
-            print("chain type", type(chain))
-            items = zip(chain.config['pv'], chain.item_to_config.items())
-            for row, (pv, (item, config)) in enumerate(items):
-                print("row", row)
-                print("pv", pv)
-                print("item", item)
-                print("config", config)
-                info_dict = dict(pv=pv)
-                info_dict.update({k: v for k, v in config.items() if k != 'field'})
-                add_dict_to_table(row, info_dict)
-                fields = config.get('field', {})
-                add_dict_to_table(row, {f'field_{k}': v
-                                        for k, v in fields.items()
-                                        if k != 'field'}
-                                  )
-
-        # self.config_info.setHorizontalHeaderLabels(list(columns))
+        # if self._mode.lower() != "chains w/o records":
+        print("chain type", type(chain))
+        items = zip(chain.config['pv'], chain.item_to_config.items())
+        for row, (pv, (item, config)) in enumerate(items):
+            #print("row", row)
+            #print("pv", pv)
+            #print("item", item)
+            #print("config", config)
+            # info_dict is a collection of the non-field pragma lines 
+            info_dict = dict(pv=pv)
+            info_dict.update({k: v for k, v in config.items() if k != 'field'})
+            add_dict_to_table(row, info_dict)
+            print("info_dict")
+            print(info_dict)
+            # fields is a dictionary exclusively contining fields
+            fields = config.get('field', {})
+            add_dict_to_table(row, {f'field_{k}': v
+                                    for k, v in fields.items()
+                                    if k != 'field'}
+                              )
+            print("fields")
+            print(fields)
+        
+        # setColumnCount seems to need to proceed the setHorizontalHeaderLabels
+        # in order to prevent QT from incorrectly drawing/labeling the cols 
+        self.config_info.setColumnCount(len(columns))
+        self.config_info.setHorizontalHeaderLabels(list(columns))
         self.config_info.setVerticalHeaderLabels(
             list(item.name for item in chain.item_to_config))
         
@@ -245,10 +263,10 @@ class TmcSummary(QtWidgets.QMainWindow):
             # print(item.Properties)
             # print(dir(item.Properties))
 
-        self.config_info.setColumnCount(
-            max(columns.values()) + 1
-            if columns else 0
-        )
+        #self.config_info.setColumnCount(
+        #    max(columns.values()) + 1
+        #    if columns else 0
+        #)
 
     def _update_record_text(self, record):
         'Slot - update record text when a new record is selected'

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -218,33 +218,56 @@ class TmcSummary(QtWidgets.QMainWindow):
                 key = str(key)
                 if key not in columns:
                     columns[key] = max(columns.values()) + 1 if columns else 0
-                self.config_info.setItem(
-                    row, columns[key], QtWidgets.QTableWidgetItem(str(value))
-                )
+                print("row:")
+                print(row)
+                print("key:")
+                print(key)
+                print("columns[key]")
+                print(columns[key])
+                print("value:")
+                print(value)
                 if isinstance(value, dict):
-                    add_dict_to_table(row, value)
+                    yield from (row, value)
+                else:
+                    yield (
+                        row, columns[key],
+                        QtWidgets.QTableWidgetItem(str(value))
+                    )
 
         columns = {}
+        column_write_entries = []
 
         items = zip(chain.config['pv'], chain.item_to_config.items())
         for row, (pv, (item, config)) in enumerate(items):
+            print("config:***************")
+            print(config)
             # info_dict is a collection of the non-field pragma lines
             info_dict = dict(pv=pv)
             if config is not None:
                 info_dict.update(
                     {k: v for k, v in config.items() if k != 'field'})
-                add_dict_to_table(row, info_dict)
+                new_entries = add_dict_to_table(row, info_dict)
+                column_write_entries.extend(new_entries)
                 # fields is a dictionary exclusively contining fields
                 fields = config.get('field', {})
-                add_dict_to_table(row, {f'field_{k}': v
+                print("fields:")
+                print(fields)
+                new_entries = add_dict_to_table(row, {f'field_{k}': v
                                         for k, v in fields.items()
                                         if k != 'field'}
                                   )
+                column_write_entries.extend(new_entries)
 
         # setColumnCount seems to need to proceed the setHorizontalHeaderLabels
         # in order to prevent QT from incorrectly drawing/labeling the cols
         self.config_info.setColumnCount(len(columns))
         self.config_info.setHorizontalHeaderLabels(list(columns))
+        print(column_write_entries)
+        for line in column_write_entries:
+            print(line)
+            if line:
+                self.config_info.setItem(*line)
+
         self.config_info.setVerticalHeaderLabels(
             list(item.name for item in chain.item_to_config))
 

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -92,11 +92,13 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.chains = {}
         self.records = {}
 
-        records, self.exceptions = process(tmc, allow_errors=True,
+        good_records, self.exceptions = process(tmc, allow_errors=True,
+            allow_no_pragma=False)
+        
+        all_records, self.exceptions = process(tmc, allow_errors=True,
             allow_no_pragma=True)
-        print(records)
-
-        for record in records:
+        
+        for record in good_records:
             self.chains[record.tcname] = record
             try:
                 record_text = record.render()

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -193,6 +193,8 @@ class TmcSummary(QtWidgets.QMainWindow):
 
     def _update_config_info(self, record):
         'Slot - update config information when a new record is selected'
+        if self._mode.lower() == "chains w/o records":
+            return
         chain = record.chain
 
         self.config_info.clear()
@@ -233,7 +235,10 @@ class TmcSummary(QtWidgets.QMainWindow):
 
     def _update_record_text(self, record):
         'Slot - update record text when a new record is selected'
-        self.record_text.setText(self.records[record])
+        if self._mode.lower() == "chains w/o records":
+            self.record_text.setText("NOT GENERATED")
+        else:
+            self.record_text.setText(self.records[record])
 
     def _update_chain_info(self, record):
         'Slot - update chain information when a new record is selected'

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -226,6 +226,8 @@ class TmcSummary(QtWidgets.QMainWindow):
                 print(columns[key])
                 print("value:")
                 print(value)
+                # accumulate a list of entries to print in the chart. These
+                # should only be printed after `setColumnCount` has been run
                 if isinstance(value, dict):
                     yield from (row, value)
                 else:
@@ -262,6 +264,7 @@ class TmcSummary(QtWidgets.QMainWindow):
         # in order to prevent QT from incorrectly drawing/labeling the cols
         self.config_info.setColumnCount(len(columns))
         self.config_info.setHorizontalHeaderLabels(list(columns))
+        # finally print the column's entries 
         print(column_write_entries)
         for line in column_write_entries:
             print(line)

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -230,7 +230,13 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         # if self._mode.lower() != "chains w/o records":
         print("chain type", type(chain))
-        items = zip(chain.config['pv'], chain.item_to_config.items())
+        items = list(zip(chain.config['pv'], chain.item_to_config.items()))
+        print("chain.item_to_config.items()")
+        print(chain.item_to_config.items())
+        print("chain.config['pv']")
+        print(chain.config)
+        print("items")
+        print(items)
         for row, (pv, (item, config)) in enumerate(items):
             #print("row", row)
             #print("pv", pv)
@@ -238,13 +244,19 @@ class TmcSummary(QtWidgets.QMainWindow):
             #print("config", config)
             # info_dict is a collection of the non-field pragma lines 
             info_dict = dict(pv=pv)
-            info_dict.update({k: v for k, v in config.items() if k != 'field'})
-            add_dict_to_table(row, info_dict)
+            print("Item")
+            print(item)
+            print("config")
+            print(config)
+            if config is not None:
+                info_dict.update({k: v for k, v in config.items() if k != 'field'})
+                add_dict_to_table(row, info_dict)
             print("info_dict")
             print(info_dict)
             # fields is a dictionary exclusively contining fields
-            fields = config.get('field', {})
-            add_dict_to_table(row, {f'field_{k}': v
+            if config is not None:
+                fields = config.get('field', {})
+                add_dict_to_table(row, {f'field_{k}': v
                                     for k, v in fields.items()
                                     if k != 'field'}
                               )

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -248,7 +248,8 @@ class TmcSummary(QtWidgets.QMainWindow):
                 for record, db_text in self.records.items()
             ]
         elif self._mode == "chains w/o records":
-            print("chains w/o records selected")
+            items = self.chains.items()
+            logger.warning("Not Implemented")
         else:
             return
         for name, record in sorted(items,

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -193,8 +193,8 @@ class TmcSummary(QtWidgets.QMainWindow):
 
     def _update_config_info(self, record):
         'Slot - update config information when a new record is selected'
-        if self._mode.lower() == "chains w/o records":
-            return
+        #if self._mode.lower() == "chains w/o records":
+        #    return
         chain = record.chain
 
         self.config_info.clear()
@@ -213,20 +213,25 @@ class TmcSummary(QtWidgets.QMainWindow):
 
         columns = {}
 
-        items = zip(chain.config['pv'], chain.item_to_config.items())
-        for row, (pv, (item, config)) in enumerate(items):
-            info_dict = dict(pv=pv)
-            info_dict.update({k: v for k, v in config.items() if k != 'field'})
-            add_dict_to_table(row, info_dict)
-            fields = config.get('field', {})
-            add_dict_to_table(row, {f'field_{k}': v
-                                    for k, v in fields.items()
-                                    if k != 'field'}
-                              )
+        if self._mode.lower() != "chains w/o records":
+            items = zip(chain.config['pv'], chain.item_to_config.items())
+            for row, (pv, (item, config)) in enumerate(items):
+                info_dict = dict(pv=pv)
+                info_dict.update({k: v for k, v in config.items() if k != 'field'})
+                add_dict_to_table(row, info_dict)
+                fields = config.get('field', {})
+                add_dict_to_table(row, {f'field_{k}': v
+                                        for k, v in fields.items()
+                                        if k != 'field'}
+                                  )
 
-        self.config_info.setHorizontalHeaderLabels(list(columns))
+        # self.config_info.setHorizontalHeaderLabels(list(columns))
         self.config_info.setVerticalHeaderLabels(
             list(item.name for item in chain.item_to_config))
+        
+        for item in chain.item_to_config:
+            print(item.Properties)
+            print(dir(item.Properties))
 
         self.config_info.setColumnCount(
             max(columns.values()) + 1
@@ -236,6 +241,7 @@ class TmcSummary(QtWidgets.QMainWindow):
     def _update_record_text(self, record):
         'Slot - update record text when a new record is selected'
         if self._mode.lower() == "chains w/o records":
+            # TODO: a more helpful message oculd be useful
             self.record_text.setText("NOT GENERATED")
         else:
             self.record_text.setText(self.records[record])

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -199,9 +199,12 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
 
     for item in chain:
         pragmas = list(get_pragma(item, name=pragma))
-        if not pragmas and not allow_no_pragma:
-            # If any pragma in the chain is unset, escape early
-            return []
+        if not pragmas:
+            if allow_no_pragma:
+                pragmas = ['pv:']
+            else:
+                # If any pragma in the chain is unset, escape early
+                return []
 
         if item.array_info and (item.data_type.is_complex_type or
                                 item.data_type.is_enum):

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -326,10 +326,7 @@ class SingularChain:
             # Detect Nones signifying an incomplete pragma
             if item_to_config[config] is None:
                 self.valid = False
-                #self.config = None
-                #self.pvname = None
 
-        # if self.valid:
         self.config = squash_configs(*list(item_to_config.values()))
         self.pvname = ':'.join(pv_segment for pv_segment in self.config['pv']
                                if pv_segment)

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -322,9 +322,6 @@ class SingularChain:
         self.tcname = '.'.join(part.name for part in self.chain)
         
         self.valid = True
-        
-        print("item_to_config")
-        print(item_to_config)
 
         for config in item_to_config:
             # Detect Nones signifying an incomplete pragma

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -198,11 +198,10 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
                                       expand_default=expand_default))
 
     for item in chain:
-        if not allow_no_pragma:
-            pragmas = list(get_pragma(item, name=pragma))
-            if not pragmas:
-                # If any pragma in the chain is unset, escape early
-                return []
+        pragmas = list(get_pragma(item, name=pragma))
+        if not pragmas and not allow_no_pragma:
+            # If any pragma in the chain is unset, escape early
+            return []
 
         if item.array_info and (item.data_type.is_complex_type or
                                 item.data_type.is_enum):

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -208,21 +208,20 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
         if not pragmas:
             if allow_no_pragma:
                 pragmas = [None]
+                result.append([(item, None)])
+                continue
             else:
                 # If any pragma in the chain is unset, escape early
                 return []
 
-        if allow_no_pragma:
-            result.append([(item, None)])
+        if item.array_info and (item.data_type.is_complex_type or
+                                item.data_type.is_enum):
+            dictify_func = dictify_complex_array
         else:
-            if item.array_info and (item.data_type.is_complex_type or
-                                    item.data_type.is_enum):
-                dictify_func = dictify_complex_array
-            else:
-                dictify_func = dictify_scalar
-            
+            dictify_func = dictify_scalar
         
-            result.append(list(dictify_func(item)))
+        
+        result.append(list(dictify_func(item)))
     
     return list(itertools.product(*result))
 

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -241,6 +241,8 @@ def squash_configs(*configs):
     '''
     squashed = {'pv': [], 'field': {}}
     for config in configs:
+        if config is None:
+            continue
         # Shallow copy so that we don't modify the original
         config = dict(config)
 
@@ -319,16 +321,20 @@ class SingularChain:
         self.tcname = '.'.join(part.name for part in self.chain)
         
         self.valid = True
+        
+        print("item_to_config")
+        print(item_to_config)
+
         for config in item_to_config:
             # Detect Nones signifying an incomplete pragma
             if item_to_config[config] is None:
                 self.valid = False
-                self.config = None
-                self.pvname = None
+                #self.config = None
+                #self.pvname = None
 
-        if self.valid:    
-            self.config = squash_configs(*list(item_to_config.values()))
-            self.pvname = ':'.join(pv_segment for pv_segment in self.config['pv']
+        #if self.valid:    
+        self.config = squash_configs(*list(item_to_config.values()))
+        self.pvname = ':'.join(pv_segment for pv_segment in self.config['pv']
                                if pv_segment)
 
     def __repr__(self):

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -382,11 +382,15 @@ def has_pragma(item, *, name: str = 'pytmc'):
                if pragma is not None)
 
 
+def always_true(*a, **kwargs):
+    return True
+
+
 def chains_from_symbol(symbol, *, pragma: str = 'pytmc',
                        allow_no_pragma=False):
     'Build all SingularChain instances from a Symbol'
     if allow_no_pragma:
-        condition = lambda *args, **kwargs: True
+        condition = always_true
     else:
         condition = has_pragma
     for full_chain in symbol.walk(condition=condition):

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -242,6 +242,7 @@ def squash_configs(*configs):
     squashed = {'pv': [], 'field': {}}
     for config in configs:
         if config is None:
+            squashed['pv'].append(None)
             continue
         # Shallow copy so that we don't modify the original
         config = dict(config)

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -159,7 +159,7 @@ def dictify_config(conf, array_index=None, expand_default=':%.2d'):
 
 
 def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
-                                      allow_no_pragma=False):
+                                     allow_no_pragma=False):
     '''
     Generate all possible configuration combinations
 
@@ -183,7 +183,7 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
     -------
     tuple
         Tuple of tuples. See description above.
-    
+
     '''
     result = []
 
@@ -219,10 +219,9 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
             dictify_func = dictify_complex_array
         else:
             dictify_func = dictify_scalar
-        
-        
+
         result.append(list(dictify_func(item)))
-    
+
     return list(itertools.product(*result))
 
 
@@ -320,7 +319,7 @@ class SingularChain:
         self.data_type = self.chain[-1].data_type
         self.array_info = self.chain[-1].array_info
         self.tcname = '.'.join(part.name for part in self.chain)
-        
+
         self.valid = True
 
         for config in item_to_config:
@@ -330,7 +329,7 @@ class SingularChain:
                 #self.config = None
                 #self.pvname = None
 
-        #if self.valid:    
+        # if self.valid:
         self.config = squash_configs(*list(item_to_config.values()))
         self.pvname = ':'.join(pv_segment for pv_segment in self.config['pv']
                                if pv_segment)
@@ -386,7 +385,7 @@ def has_pragma(item, *, name: str = 'pytmc'):
                if pragma is not None)
 
 
-def chains_from_symbol(symbol, *, pragma: str = 'pytmc', 
+def chains_from_symbol(symbol, *, pragma: str = 'pytmc',
                        allow_no_pragma=False):
     'Build all SingularChain instances from a Symbol'
     if allow_no_pragma:
@@ -403,7 +402,7 @@ def record_packages_from_symbol(symbol, *, pragma: str = 'pytmc',
                                 yield_exceptions=False,
                                 allow_no_pragma=False):
     'Create all record packages from a given Symbol'
-    for chain in chains_from_symbol(symbol, pragma=pragma, 
+    for chain in chains_from_symbol(symbol, pragma=pragma,
                                     allow_no_pragma=allow_no_pragma):
         try:
             yield RecordPackage.from_chain(symbol.module.ads_port, chain=chain)

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -117,6 +117,8 @@ class RecordPackage:
         bool
             Returns true if this record is fully specified and valid.
         """
+        if self.pvname is None:
+            return False
         has_required_keys = all(self.chain.config.get(key)
                                 for key in self._required_keys)
 
@@ -163,8 +165,6 @@ class RecordPackage:
                     f'Unsupported data type {data_type.name} in chain: '
                     f'{chain.tcname} record: {chain.pvname}'
                 ) from None
-        print(chain)
-        print(chain.valid)
         return spec(*args, chain=chain, **kwargs)
 
 

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -100,14 +100,11 @@ class RecordPackage:
         # Due to a twincat pragma limitation, EPICS macro prefix '$' cannot be
         # used or escaped.  Allow the configuration to specify an alternate
         # character in the pragma, defaulting to '@'.
-        try:
+        if self.chain.config is not None:
             macro_character = self.chain.config.get('macro_character', '@')
             self.pvname = chain.pvname.replace(macro_character, '$')
-        except AttributeError:
-            if self.chain.config is None:
-                self.pvname = None
-            else:
-                raise
+        else:
+            self.pvname = None
 
     @property
     def valid(self):

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -150,7 +150,7 @@ class RecordPackage:
         """Select the proper subclass of ``TwincatRecordPackage`` from chain"""
         data_type = chain.data_type
         if not chain.valid:
-            spec=RecordPackage
+            spec = RecordPackage
         elif data_type.is_enum:
             spec = EnumRecordPackage
         elif data_type.is_array or chain.last.array_info:

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -117,7 +117,7 @@ class RecordPackage:
         bool
             Returns true if this record is fully specified and valid.
         """
-        if self.pvname is None:
+        if self.pvname is None or not self.chain.valid:
             return False
         has_required_keys = all(self.chain.config.get(key)
                                 for key in self._required_keys)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -54,7 +54,7 @@ def test_allow_no_pragma():
         show_error_context=True, allow_no_pragma=True
     )
 
-    target_variable = "GVL_Devices.VCN_50.i_Req_Pos"
+    target_variable = "GVL_Devices.VCN_50.i_ReqPos"
     for x in records:
         print(x.tcname)
     assert any((target_variable in x.tcname) for x in records)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -38,3 +38,18 @@ def test_global_pinned_variables(tmc_file_name, target_pv):
 
     assert any((target_pv in x.pvname) for x in records)
     assert exceptions == []
+
+def test_allow_no_pragma():
+    tmc_file_name = PROJ_ROOT / ("lcls-plc-kfe-xgmd-vac/plc/plc-kfe-xgmd-vac/" 
+        "plc_kfe_xgmd_vac/plc_kfe_xgmd_vac.tmc")
+    
+    tmc = parser.parse(tmc_file_name)
+
+    records, exceptions = db_process(
+        tmc, dbd_file=None, allow_errors=False,
+        show_error_context=True, allow_no_pragma=True
+    )
+
+    target_variable = "GVL_Devices.VCN_50.i_Req_Pos"
+    assert any((target_variable in x.tcname) for x in records)
+    assert exceptions == []

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -40,16 +40,22 @@ def test_global_pinned_variables(tmc_file_name, target_pv):
     assert exceptions == []
 
 def test_allow_no_pragma():
+    """
+    Test for the existence of a variable included in the records, despite it
+    lacking a proper set of pragmas.
+    """
     tmc_file_name = PROJ_ROOT / ("lcls-plc-kfe-xgmd-vac/plc/plc-kfe-xgmd-vac/" 
         "plc_kfe_xgmd_vac/plc_kfe_xgmd_vac.tmc")
     
     tmc = parser.parse(tmc_file_name)
 
     records, exceptions = db_process(
-        tmc, dbd_file=None, allow_errors=False,
+        tmc, dbd_file=None, allow_errors=True,
         show_error_context=True, allow_no_pragma=True
     )
 
     target_variable = "GVL_Devices.VCN_50.i_Req_Pos"
+    for x in records:
+        print(x.tcname)
     assert any((target_variable in x.tcname) for x in records)
     assert exceptions == []

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -39,15 +39,16 @@ def test_global_pinned_variables(tmc_file_name, target_pv):
     assert any((target_pv in x.pvname) for x in records)
     assert exceptions == []
 
+
 def test_allow_no_pragma():
     """
     Test for the existence of a variable included in the records, despite it
     lacking a proper set of pragmas.
     """
     tmc_file_name = TMC_ROOT / ("xtes_sxr_plc.tmc")
-    
+
     tmc = parser.parse(tmc_file_name)
-    
+
     records, exceptions = db_process(
         tmc, dbd_file=None, allow_errors=True,
         show_error_context=True, allow_no_pragma=False
@@ -57,15 +58,15 @@ def test_allow_no_pragma():
         tmc, dbd_file=None, allow_errors=True,
         show_error_context=True, allow_no_pragma=True
     )
-    good_records=129
-    total_records=976
+    good_records = 129
+    total_records = 976
 
     assert good_records == len(records)
     assert good_records == len(list(x.valid for x in records if x.valid))
     assert total_records == len(all_records)
     assert good_records == len(list(x.valid for x in all_records if x.valid))
-    
-    # this variable lacks a pragma 
+
+    # this variable lacks a pragma
     target_variable = "GVL_DEVICES.MR2K3_GCC_1.rV"
     for x in all_records:
         print(x.tcname)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -44,18 +44,30 @@ def test_allow_no_pragma():
     Test for the existence of a variable included in the records, despite it
     lacking a proper set of pragmas.
     """
-    tmc_file_name = PROJ_ROOT / ("lcls-plc-kfe-xgmd-vac/plc/plc-kfe-xgmd-vac/" 
-        "plc_kfe_xgmd_vac/plc_kfe_xgmd_vac.tmc")
+    tmc_file_name = TMC_ROOT / ("xtes_sxr_plc.tmc")
     
     tmc = parser.parse(tmc_file_name)
-
+    
     records, exceptions = db_process(
+        tmc, dbd_file=None, allow_errors=True,
+        show_error_context=True, allow_no_pragma=False
+    )
+
+    all_records, exceptions = db_process(
         tmc, dbd_file=None, allow_errors=True,
         show_error_context=True, allow_no_pragma=True
     )
+    good_records=129
+    total_records=976
 
-    target_variable = "GVL_Devices.VCN_50.i_ReqPos"
-    for x in records:
+    assert good_records == len(records)
+    assert good_records == len(list(x.valid for x in records if x.valid))
+    assert total_records == len(all_records)
+    assert good_records == len(list(x.valid for x in all_records if x.valid))
+    
+    # this variable lacks a pragma 
+    target_variable = "GVL_DEVICES.MR2K3_GCC_1.rV"
+    for x in all_records:
         print(x.tcname)
-    assert any((target_variable in x.tcname) for x in records)
+    assert any((target_variable == x.tcname) for x in all_records)
     assert exceptions == []


### PR DESCRIPTION
Adds a category to the debug interface to show TwinCAT variable chains that have *not* been fully rendered to records. Alterations have been made to the chain generation procedures to make it less dependent upon record generation to allow flawed records to be generated.
closes #147 

Also addresses some oddities in the debug interface's config_info table not drawing properly. 
closes #158 