### PR TITLE
FIX: off by one error in complex array unrolling

### DIFF
--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -223,7 +223,7 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
         expand_default = f':%.{expand_digits}d'
         for pvname, config in separate_configs_by_pv(
                 split_pytmc_pragma('\n'.join(pragmas))):
-            for idx in range(low, high):
+            for idx in range(low, high + 1):
                 yield (parser._ArrayItemProxy(item, idx),
                        dictify_config(config, array_index=idx,
                                       expand_default=expand_default))

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -322,7 +322,7 @@ def test_complex_array():
     array = make_mock_twincatitem(
         name='array_base',
         data_type=make_mock_type('MY_DUT', is_complex_type=True),
-        pragma='pv: ARRAY', array_info=(1, 5))
+        pragma='pv: ARRAY', array_info=(1, 4))
 
     subitem1 = make_mock_twincatitem(
         name='subitem1', data_type=make_mock_type('INT'),
@@ -363,7 +363,7 @@ def test_enum_array():
         name='enum_array',
         data_type=make_mock_type('MY_ENUM', is_enum=True,
                                  enum_dict={1: 'ONE', 2: 'TWO'}),
-        pragma='pv: ENUMS', array_info=(1, 5)
+        pragma='pv: ENUMS', array_info=(1, 4)
     )
 
     records = {
@@ -392,7 +392,7 @@ def test_unroll_formatting():
         name='enum_array',
         data_type=make_mock_type('MY_ENUM', is_enum=True,
                                  enum_dict={1: 'ONE', 2: 'TWO'}),
-        pragma='pv: ENUMS\nexpand: _EXPAND%d', array_info=(1, 5)
+        pragma='pv: ENUMS\nexpand: _EXPAND%d', array_info=(1, 4)
     )
 
     records = {


### PR DESCRIPTION
The off-by-one error in array bounds fix in #169 created a new off-by-one error in the code introduced in #121 that was relying on the previously off-by-one value. This fixes the issue.