### PR TITLE
ENH: full source code + access to actions

### DIFF
--- a/pytmc/bin/code.py
+++ b/pytmc/bin/code.py
@@ -4,12 +4,9 @@ TwinCAT3 .tsproj projects.
 """
 
 import argparse
-import ast
 import pathlib
-import sys
 
 from .. import parser
-from . import util
 
 
 DESCRIPTION = __doc__

--- a/pytmc/bin/code.py
+++ b/pytmc/bin/code.py
@@ -1,0 +1,75 @@
+"""
+"pytmc code" is a command line utility for extracting the source code of
+TwinCAT3 .tsproj projects.
+"""
+
+import argparse
+import ast
+import pathlib
+import sys
+
+from .. import parser
+from . import util
+
+
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+    argparser.add_argument(
+        'filename', type=str,
+        help='Path to project (.tsproj)'
+    )
+
+    return argparser
+
+
+def dump_source_code(tsproj_project):
+    'Return the source code for a given tsproj project'
+    proj_path = pathlib.Path(tsproj_project)
+
+    if proj_path.suffix.lower() not in ('.tsproj', ):
+        raise ValueError('Expected a .tsproj file')
+
+    project = parser.parse(proj_path)
+    full_source = []
+
+    for plc in project.plcs:
+        source_items = (
+            list(plc.dut_by_name.items()) +
+            list(plc.gvl_by_name.items()) +
+            list(plc.pou_by_name.items())
+        )
+        for name, source in source_items:
+            if hasattr(source, 'get_source_code'):
+                source_text = source.get_source_code() or ''
+                if source_text.strip():
+                    full_source.append(source_text)
+
+    return project, '\n\n'.join(full_source)
+
+
+def main(filename):
+    '''
+    Output the source code of a project given its filename.
+    '''
+
+    path = pathlib.Path(filename)
+    if path.suffix.lower() in ('.tsproj', ):
+        project_fns = [path]
+    else:
+        raise ValueError(f'Expected a tsproj, but got: {path.suffix}')
+
+    projects = []
+    for fn in project_fns:
+        project, source_code = dump_source_code(fn)
+        print(source_code)
+        projects.append(project)
+
+    return projects

--- a/pytmc/bin/code.py
+++ b/pytmc/bin/code.py
@@ -66,10 +66,10 @@ def main(filename):
     else:
         raise ValueError(f'Expected a tsproj, but got: {path.suffix}')
 
-    projects = []
+    projects = {}
     for fn in project_fns:
         project, source_code = dump_source_code(fn)
         print(source_code)
-        projects.append(project)
+        projects[project] = source_code
 
     return projects

--- a/pytmc/bin/pytmc.py
+++ b/pytmc/bin/pytmc.py
@@ -16,7 +16,7 @@ DESCRIPTION = __doc__
 
 
 MODULES = ('summary', 'stcmd', 'db', 'xmltranslate', 'debug', 'types',
-           'iocboot', 'pragmalint')
+           'iocboot', 'pragmalint', 'code')
 
 
 def _try_import(module):

--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -142,30 +142,28 @@ def summary(tsproj_project, use_markdown=False, show_all=False,
                     print()
 
             if show_code:
-                for fn, source in plc.source.items():
-                    util.sub_heading(f'{fn} ({source.tag})')
-                    for decl_or_impl in source.find((parser.ST,
-                                                     parser.Declaration,
-                                                     parser.Implementation)):
-                        source_text = decl_or_impl.text
-                        if source_text is None or not source_text.strip():
-                            continue
+                source_items = (
+                    list(plc.dut_by_name.items()) +
+                    list(plc.gvl_by_name.items()) +
+                    list(plc.pou_by_name.items())
+                )
+                for name, source in source_items:
+                    util.sub_heading(f'{source.tag}: {name}')
 
-                        parent = decl_or_impl.parent
-                        path_to_source = []
-                        while parent is not source:
-                            if parent.name is not None:
-                                path_to_source.insert(0, parent.name)
-                            parent = parent.parent
-                        util.sub_sub_heading(
-                            f'{".".join(path_to_source)}: {decl_or_impl.tag}',
-                            use_markdown=use_markdown
-                        )
+                    fn = source.filename.resolve().relative_to(proj_root)
+                    print(f'File: {fn}')
+                    print()
+
+                    if not hasattr(source, 'get_source_code'):
+                        continue
+
+                    source_text = source.get_source_code() or ''
+                    if source_text.strip():
                         util.text_block(
                             source_text,
                             markdown_language='vhdl' if use_markdown else None
                         )
-                    print()
+                        print()
 
             if show_symbols or show_all:
                 util.sub_heading('Symbols')

--- a/pytmc/code.py
+++ b/pytmc/code.py
@@ -9,6 +9,12 @@ import re
 logger = logging.getLogger(__name__)
 
 
+RE_FUNCTION_BLOCK = re.compile(r'^FUNCTION_BLOCK\s', re.MULTILINE)
+RE_PROGRAM = re.compile(r'^PROGRAM\s', re.MULTILINE)
+RE_FUNCTION = re.compile(r'^FUNCTION\s', re.MULTILINE)
+RE_ACTION = re.compile(r'^ACTION\s', re.MULTILINE)
+
+
 def program_name_from_declaration(declaration):
     '''
     Determine a program name from a given declaration
@@ -21,6 +27,25 @@ def program_name_from_declaration(declaration):
         line = line.strip()
         if line.lower().startswith('program '):
             return line.split(' ')[1]
+
+
+def determine_block_type(code):
+    '''
+    Determine the code block type, looking for e.g., PROGRAM or FUNCTION_BLOCk
+
+    Returns
+    -------
+    {'function_block', 'program', 'function', 'action'} or None
+    '''
+    checks = [(RE_FUNCTION_BLOCK, 'function_block'),
+              (RE_FUNCTION, 'function'),
+              (RE_PROGRAM, 'program'),
+              (RE_ACTION, 'action'),
+              # TODO: others?
+              ]
+    for regex, block_type in checks:
+        if regex.search(code):
+            return block_type
 
 
 def lines_between(text, start_marker, end_marker, *, include_blank=False):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -984,23 +984,28 @@ class Symbol_DUT_MotionStage(Symbol):
 
 
 class GVL(_TwincatProjectSubItem):
-    '[XTI] A Global Variable List'
+    '[TcGVL] A Global Variable List'
 
 
 class ST(_TwincatProjectSubItem):
-    '[XTI] Structured text'
+    '[TcDUT/TcPOU] Structured text'
 
 
 class Implementation(_TwincatProjectSubItem):
-    '[XTI] Code implementation'
+    '[TcDUT/TcPOU] Code implementation'
 
 
 class Declaration(_TwincatProjectSubItem):
-    '[XTI] Code declaration'
+    '[TcDUT/TcPOU/TcGVL] Code declaration'
+
+
+class DUT(_TwincatProjectSubItem):
+    '[TcDUT] Data unit type (DUT)'
 
 
 class Action(_TwincatProjectSubItem):
-    '[XTI] Code declaration for actions'
+    '[TcPOU] Code declaration for actions'
+
     @property
     def source_code(self):
         return f'''\

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -504,6 +504,13 @@ class Plc(TwincatItem):
             and plc_obj.GVL[0].name
         }
 
+        self.dut_by_name = {
+            plc_obj.DUT[0].name: plc_obj.DUT[0]
+            for plc_obj in self.source.values()
+            if hasattr(plc_obj, 'DUT')
+            and plc_obj.DUT[0].name
+        }
+
         self.namespaces.update(self.pou_by_name)
         self.namespaces.update(self.gvl_by_name)
 
@@ -986,6 +993,11 @@ class Symbol_DUT_MotionStage(Symbol):
 class GVL(_TwincatProjectSubItem):
     '[TcGVL] A Global Variable List'
 
+    @property
+    def declaration(self):
+        'The declaration code; i.e., the top portion in visual studio'
+        return self.Declaration[0].text
+
 
 class ST(_TwincatProjectSubItem):
     '[TcDUT/TcPOU] Structured text'
@@ -1001,6 +1013,11 @@ class Declaration(_TwincatProjectSubItem):
 
 class DUT(_TwincatProjectSubItem):
     '[TcDUT] Data unit type (DUT)'
+
+    @property
+    def declaration(self):
+        'The declaration code; i.e., the top portion in visual studio'
+        return self.Declaration[0].text
 
 
 class Action(_TwincatProjectSubItem):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -12,7 +12,9 @@ import lxml
 import lxml.etree
 
 from .code import (get_pou_call_blocks, program_name_from_declaration,
-                   variables_from_declaration)
+                   variables_from_declaration, determine_block_type)
+
+
 # Registry of all TwincatItem-based classes
 TWINCAT_TYPES = {}
 USE_FILE_AS_PATH = object()
@@ -1095,14 +1097,16 @@ class POU(_TwincatProjectSubItem):
 
         if close_block:
             source_code.append('')
-            # TODO: compile
-            if re.search(r'^FUNCTION_BLOCK\s', self.declaration, re.MULTILINE):
-                source_code.append('END_FUNCTION_BLOCK')
-            elif re.search(r'^PROGRAM\s', self.declaration, re.MULTILINE):
-                source_code.append('END_PROGRAM')
-            elif re.search(r'^FUNCTION\s', self.declaration, re.MULTILINE):
-                source_code.append('END_FUNCTION')
-            # TODO: others?
+            closing = {
+                'function_block': 'END_FUNCTION_BLOCK',
+                'program': 'END_PROGRAM',
+                'function': 'END_FUNCTION',
+                'action': 'END_ACTION',
+            }
+            source_code.append(
+                closing.get(determine_block_type(self.declaration),
+                            '# pytmc: unknown block type')
+            )
 
         # TODO: actions defined outside of the block?
         for action in self.actions:

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -998,6 +998,10 @@ class GVL(_TwincatProjectSubItem):
         'The declaration code; i.e., the top portion in visual studio'
         return self.Declaration[0].text
 
+    def get_source_code(self, *, close_block=True):
+        'The full source code - declaration only in the case of a GVL'
+        return self.declaration
+
 
 class ST(_TwincatProjectSubItem):
     '[TcDUT/TcPOU] Structured text'
@@ -1018,6 +1022,10 @@ class DUT(_TwincatProjectSubItem):
     def declaration(self):
         'The declaration code; i.e., the top portion in visual studio'
         return self.Declaration[0].text
+
+    def get_source_code(self, *, close_block=True):
+        'The full source code - declaration only in the case of a DUT'
+        return self.declaration
 
 
 class Action(_TwincatProjectSubItem):

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -9,6 +9,7 @@ from pytmc.bin.stcmd import main as stcmd_main
 from pytmc.bin.summary import main as summary_main
 from pytmc.bin.types import create_types_gui
 from pytmc.bin.xmltranslate import main as xmltranslate_main
+from pytmc.bin.code import main as code_main
 
 
 def test_help_main(monkeypatch):
@@ -75,3 +76,7 @@ def test_types(qtbot, tmc_filename):
 def test_debug(qtbot, tmc_filename):
     widget = create_debug_gui(tmc_filename)
     qtbot.addWidget(widget)
+
+
+def test_code(project_filename):
+    code_main(project_filename)


### PR DESCRIPTION
* Adds `POU.get_source_code` method
* Provides easier access to Actions (e.g., `FB_Name.Action();` - equivalent of Python methods, pretty much)

- [ ] I'm not 100% on the ST syntax of actions outside of a `.TcPOU` file (can anyone find an example?).
- [x] This PR also has a bit too much in the way of TODOs. That said, it still offers an improvement over master in that action source code can easily be retrieved from POUs.
- [x] I think `pytmc summary` should probably rely on `get_source_code`, which should clean up our html docs as well.

(Aside: this PR pairs with my airplane/weekend side-project that allowed me to somewhat stave off jet lag, https://github.com/klauer/blark/ - an IEC61311-3 structured text parser using an Earley parser from [Lark](https://github.com/lark-parser/lark/). Having a full parser for structured text POUs may allow us to do some sort of static analysis, generate more thorough documentation, and who knows what else. It parses _almost_ all of the PCDS code I've downloaded locally, with a few exceptions...)