### PR TITLE
FIX: autosave info node names incorrect

### DIFF
--- a/docs/pragma_usage.rst
+++ b/docs/pragma_usage.rst
@@ -399,10 +399,10 @@ autosaving:
 
    record(ai, "my:record_RBV") {
       ...
-      info(autosave_pass0, "VAL DESC")
+      info(autosaveFields_pass0, "VAL DESC")
    }
 
    record(ao, "my:record") {
       ...
-      info(autosave_pass0, "VAL DESC")
+      info(autosaveFields_pass0, "VAL DESC")
    }

--- a/pytmc/templates/asyn_standard_record.jinja2
+++ b/pytmc/templates/asyn_standard_record.jinja2
@@ -6,9 +6,10 @@ record({{record.record_type}}, "{{record.pvname}}") {
 {% for f in record.fields%}
   field({{f}}, "{{record.fields[f]}}")
 {% endfor %}
-{% for autosave_pass in ['pass0', 'pass1'] %}
-    {% if record.autosave[autosave_pass] %}
-  info(autosave_{{autosave_pass}}, "{{ record.autosave[autosave_pass] | sort | join(' ') }}")
-    {% endif %}
-{% endfor %}
+{% if record.autosave['pass1'] %}
+  info(autosaveFields, "{{ record.autosave['pass1'] | sort | join(' ') }}")
+{% endif %}
+{% if record.autosave['pass0'] %}
+  info(autosaveFields_pass0, "{{ record.autosave['pass0'] | sort | join(' ') }}")
+{% endif %}
 }


### PR DESCRIPTION
Closes #176 

Autosave fields seems to be lacking tests (future TODO)

Also for the future: we might consider using `makeAutosaveFileFromDbInfo` in ads-ioc to have more control over autosave's functionality