### PR TITLE
FIX: config/io path loading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "tests/projects/lcls-twincat-pmps"]
 	path = tests/projects/lcls-twincat-pmps
 	url = https://github.com/pcdshub/lcls-twincat-pmps.git
+[submodule "tests/projects/lcls-plc-kfe-gmd-vac-ext-io"]
+	path = tests/projects/lcls-plc-kfe-gmd-vac-ext-io
+	url = git://github.com/n-wbrown/lcls-plc-kfe-gmd-vac.git

--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -233,7 +233,9 @@ def main(tsproj_project, *, name=None, prefix=None,
     motors = [mot for mot in symbols['Symbol_DUT_MotionStage']
               if not mot.is_pointer]
 
-    if not only_motor:
+    if plc.tmc is None:
+        logger.warning('No TMC file found; no records to be generated')
+    elif not only_motor:
         other_records, _ = db.process(plc.tmc,
                                       dbd_file=dbd,
                                       allow_errors=allow_errors)

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -45,14 +45,13 @@ def test_pragmalint(project_filename, project_filename_linter_success):
     pragmalint_main(project_filename, verbose=True, use_markdown=True)
 
 
-def test_stcmd(project_filename):
-    if 'plc_kfe_xgmd_vac' in project_filename:
-        kwargs = dict(plc_name='plc_kfe_xgmd_vac')
-    elif 'lcls-twincat-motion' in project_filename:
-        kwargs = dict(plc_name='Example', allow_errors=True)
-    else:
-        kwargs = {}
-    stcmd_main(project_filename, **kwargs)
+def test_stcmd(project_and_plc):
+    project_filename = project_and_plc.project
+    plc_name = project_and_plc.plc_name
+    allow_errors = any(name in project_filename
+                       for name in ('lcls-twincat-motion', 'XtesSxrPlc',
+                                    'plc-kfe-gmd-vac'))
+    stcmd_main(project_filename, plc_name=plc_name, allow_errors=allow_errors)
 
 
 def test_xmltranslate(project_filename):


### PR DESCRIPTION
I don't have much faith in the correctness of this, but it appears to load all (valid) tsproj files I have on hand, including those in the test suite.

* Added https://github.com/n-wbrown/lcls-plc-kfe-gmd-vac/commit/4b4105124f5ca00aac6353d7b8c58e12ac4ba333 as a submodule, which should close #179 