### PR TITLE
Describe process error

### DIFF
--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -116,7 +116,7 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
                   if isinstance(ex, Exception)]
 
     for ex in exceptions:
-        logger.error('Error creating record: %s ', ex)
+        logger.error('Error creating record: %s', ex)
         records.remove(ex)
 
     if exceptions and not allow_errors:

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -113,10 +113,10 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
     ]
 
     exceptions = [ex for ex in records
-                  if isinstance(ex, dict)]
+                  if isinstance(ex, Exception)]
 
     for ex in exceptions:
-        logger.error('Error creating record: %s %s', ex['tcname'], ex['ex'])
+        logger.error('Error creating record: %s ', ex)
         records.remove(ex)
 
     if exceptions and not allow_errors:

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -112,8 +112,6 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
             symbol, yield_exceptions=True, allow_no_pragma=allow_no_pragma)
     ]
 
-    #exceptions = [ex for ex in records
-    #              if isinstance(ex['ex'], Exception)]
     exceptions = [ex for ex in records
                   if isinstance(ex, dict)]
 

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -112,11 +112,13 @@ def process(tmc, *, dbd_file=None, allow_errors=False,
             symbol, yield_exceptions=True, allow_no_pragma=allow_no_pragma)
     ]
 
+    #exceptions = [ex for ex in records
+    #              if isinstance(ex['ex'], Exception)]
     exceptions = [ex for ex in records
-                  if isinstance(ex, Exception)]
+                  if isinstance(ex, dict)]
 
     for ex in exceptions:
-        logger.error('Error creating record: %s', ex)
+        logger.error('Error creating record: %s %s', ex['tcname'], ex['ex'])
         records.remove(ex)
 
     if exceptions and not allow_errors:

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -586,6 +586,6 @@ def record_packages_from_symbol(symbol, *, pragma: str = 'pytmc',
             yield RecordPackage.from_chain(symbol.module.ads_port, chain=chain)
         except Exception as ex:
             if yield_exceptions:
-                yield ex
+                yield {'ex': ex, 'tcname': chain.tcname}
             else:
                 raise

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -586,6 +586,6 @@ def record_packages_from_symbol(symbol, *, pragma: str = 'pytmc',
             yield RecordPackage.from_chain(symbol.module.ads_port, chain=chain)
         except Exception as ex:
             if yield_exceptions:
-                yield {'ex': ex, 'tcname': chain.tcname}
+                yield type(ex)(f"{chain.tcname} {ex.args[0]}")
             else:
                 raise


### PR DESCRIPTION
Provide the name of TwinCAT variable when the db.process fails to build a record from the chain. 

Example output:
```
ERROR:pytmc.bin.db:Error creating record: GVL_GMD.fb_EM1K0_GMD_GPI_10.PG.eState 'EnumInfo' object has no attribute 'Enum'
```
Open to feedback as always. 