### PR TITLE
ENH: warn if Enum value missing

### DIFF
--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -616,7 +616,17 @@ class EnumInfo(_TmcItem):
 
     @property
     def enum_value(self):
-        return self.Enum[0].text
+        try:
+            return self.Enum[0].text
+        except AttributeError:
+            ...
+
+        logger.warning(
+            'Encountered a known issue with the TwinCAT-generated TMC file: '
+            '%s is missing an Enum value in section %s; this may database '
+            'generation failures.', self.parent.name, self.path
+        )
+        return ''
 
     @property
     def enum_comment(self):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -623,8 +623,8 @@ class EnumInfo(_TmcItem):
 
         logger.warning(
             'Encountered a known issue with the TwinCAT-generated TMC file: '
-            '%s is missing an Enum value in section %s; this may database '
-            'generation failures.', self.parent.name, self.path
+            '%s is missing an Enum value in section %s; this may cause '
+            'database generation errors.', self.parent.name, self.path
         )
         return ''
 


### PR DESCRIPTION
Referenced global variable in an EnumInfo block sometimes does not generate the Enum value field:
 
Code:
```vhdl
VAR_GLOBAL CONSTANT
     gc_iSizeOfGGOArray : INT := 50;
     gc_GaugeValidState :  INT := 10;
END_VAR
 
TYPE E_PressureState :
(
     //Valid States (Positive)
     Valid := gc_GaugeValidState, // gc_GaugeValidState set in "Global Variable Folder: Constants"
     ValidHi    := 11, //gc_GaugeValidState + 1,
     ValidLo    := 12, //gc_GaugeValidState + 2,
    
     // Invalid states
     PressInvalid    := 1, //gc_GaugeValidState - 1,
     GaugeDisconnected     :=   2, //gc_GaugeValidState -2,
     OoR  := 6, //gc_GaugeValidState -6,
     // Ion gauges
     Off        := 3, //gc_GaugeValidState - 3,
     Starting   := 4 //gc_GaugeValidState - 4
) INT;
END_TYPE
```

Relevant portion of the TMC:
```
      <EnumInfo>
        <Text>Valid</Text>
        <Comment><![CDATA[ gc_GaugeValidState set in "Global Variable Folder: Constants"]]></Comment>
      </EnumInfo>
 ```

This adds a warning and doesn't immediately fail the build, but will cause the records to not be generated as `''` is not a valid integer.