### PR TITLE
ENH: special syntax to allow for referring to PV name in linked variable

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -418,9 +418,23 @@ class TwincatTypeRecordPackage(RecordPackage):
         record.fields.pop('PINI', None)
 
         if self.linked_to_pv and self.linked_to_pv[-1] is not None:
+
             record.fields['OMSL'] = 'closed_loop'
-            linked_to_pv = ''.join([part for part in self.linked_to_pv
-                                    if part is not None])
+
+            last_link = self.linked_to_pv[-1]
+            if last_link.startswith('*'):
+                # NOTE: A special, undocumented syntax for a lack of a better
+                # idea/more time:  need to allow pytmc to get access to a PV
+                # name it generates
+                # Consider this temporary API, only to be used in
+                # lcls-twincat-general for now.
+                pv_parts = list(self.config['pv'])
+                linked_to_pv = ':'.join(pv_parts[:-1] +
+                                        [last_link.lstrip('*')])
+            else:
+                linked_to_pv = ''.join([part for part in self.linked_to_pv
+                                        if part is not None])
+
             record.fields['DOL'] = linked_to_pv + ' CPP MS'
             record.fields['SCAN'] = self.config.get('link_scan', '.5 second')
 

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -421,3 +421,23 @@ def test_pv_linking():
     assert rec.fields['OMSL'] == 'closed_loop'
     assert rec.fields['DOL'] == 'OTHER:RECORD CPP MS'
     assert rec.fields['SCAN'] == '.5 second'
+
+
+def test_pv_linking_special():
+    struct = make_mock_twincatitem(
+        name='array_base',
+        data_type=make_mock_type('MY_DUT', is_complex_type=True),
+        pragma='pv: PREFIX')
+
+    subitem1 = make_mock_twincatitem(
+        name='subitem1', data_type=make_mock_type('INT'),
+        pragma='pv: ABCD; link: **ABCD.STAT')
+
+    def walk(condition=None):
+        yield [struct, subitem1]
+
+    struct.walk = walk
+
+    pkg, = list(pragmas.record_packages_from_symbol(struct))
+    rec = pkg.generate_output_record()
+    assert rec.fields['DOL'] == 'PREFIX:ABCD.STAT CPP MS'


### PR DESCRIPTION
This is subject to change and as such I don't want it to be documented just yet (I know, I know...)

Hoping to get this in for a paired PR in lcls-twincat-general shortly (assuming tests pass).