### PR TITLE
REF: rework the archive settings to add info(archive) nodes

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -120,6 +120,7 @@ class RecordPackage:
     """
     _required_keys = {}
     _required_fields = {}
+    archive_fields = []
 
     def __init__(self, ads_port, chain=None, origin=None):
         """

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -43,7 +43,8 @@ class EPICSRecord:
     """Representation of a single EPICS Record"""
 
     def __init__(self, pvname, record_type, direction, fields=None,
-                 template=None, autosave=None, aliases=None):
+                 template=None, autosave=None, aliases=None,
+                 archive_settings=None):
         self.pvname = pvname
         self.record_type = record_type
         self.direction = direction
@@ -51,6 +52,11 @@ class EPICSRecord:
         self.aliases = list(aliases) if aliases is not None else []
         self.template = template or 'asyn_standard_record.jinja2'
         self.autosave = dict(autosave) if autosave else {}
+        self.archive_settings = (dict(archive_settings)
+                                 if archive_settings else {})
+
+        if 'fields' not in self.archive_settings:
+            self.archive_settings = {}
 
         # Load jinja templates
         self.jinja_env = Environment(
@@ -183,9 +189,11 @@ class RecordPackage:
         'Parse archive settings pragma key (archive_settings attribute)'
         self.archive_settings = archive_settings
         if archive_settings:
-            archive_settings['fields'] = (
-                archive_fields.split(' ') if archive_fields else []
-            )
+            # Fields are those from the pragma (key: archive_fields) plus
+            # those set by default on the RecordPackage class
+            fields = set(archive_fields.split(' ')
+                         if archive_fields else [])
+            archive_settings['fields'] = fields.union(set(self.archive_fields))
 
     @property
     def valid(self):
@@ -368,6 +376,7 @@ class TwincatTypeRecordPackage(RecordPackage):
                              fields=self.field_defaults,
                              autosave=self.autosave_defaults.get('input'),
                              aliases=aliases,
+                             archive_settings=self.archive_settings,
                              )
 
         # Set a default description to the tcname
@@ -404,6 +413,7 @@ class TwincatTypeRecordPackage(RecordPackage):
                              fields=self.field_defaults,
                              autosave=self.autosave_defaults.get('output'),
                              aliases=self.aliases,
+                             archive_settings=self.archive_settings,
                              )
 
         # Set a default description to the tcname
@@ -717,11 +727,7 @@ def generate_archive_settings(packages):
         if archive_settings:
             # for record in package.records:
             for record in package.records:
-                # Fields are those from the pragma (key: archive_fields) plus
-                # those set by default on the RecordPackage class
-                fields = sorted(set(archive_settings['fields'] +
-                                    package.archive_fields))
-                for field in fields:
+                for field in sorted(archive_settings['fields']):
                     period = archive_settings['seconds']
                     update_rate = package.config['update']['seconds']
                     if period < update_rate:

--- a/pytmc/templates/asyn_standard_record.jinja2
+++ b/pytmc/templates/asyn_standard_record.jinja2
@@ -12,4 +12,11 @@ record({{record.record_type}}, "{{record.pvname}}") {
 {% if record.autosave['pass0'] %}
   info(autosaveFields_pass0, "{{ record.autosave['pass0'] | sort | join(' ') }}")
 {% endif %}
+{% if record.archive_settings %}
+  {% if record.archive_settings['method'] == 'scan' and record.archive_settings['seconds'] == 1 %}
+  info(archive, "{{ record.archive_settings['fields'] | join(' ') }}")
+  {% else %}
+  info(archive, "{{ record.archive_settings['method'] }} {{ record.archive_settings['seconds'] }}: {{ record.archive_settings['fields'] | join(' ') }}")
+  {% endif %}
+{% endif %}
 }


### PR DESCRIPTION
Pairs with https://github.com/pcdshub/ads-ioc/pull/33

Still can generate `.archive` files separately, but also adds info nodes.

Example from an old test tmc:
```
# pragma:
#     (archive not specified in tmc)
record(bi, "fb:EM1K0:GMD:PRT:40:ALARM_OK_RBV") {
  ... 
  info(archive, "VAL")
}

# pragma:
#     archive: 2s monitor
#     archive_fields: VAL DESC
record(bi, "fb:EM1K0:GMD:PRT:40:RUN_DI_RBV") {
...  
  info(archive, "monitor 2: VAL DESC")
}
```