### PR TITLE
FIX: pragma parse failure with information about symbol/chain

### DIFF
--- a/pytmc/bin/pytmc.py
+++ b/pytmc/bin/pytmc.py
@@ -39,7 +39,7 @@ def _build_commands():
             DESCRIPTION += f'\n    $ pytmc {module} --help'
 
     if unavailable:
-        DESCRIPTION += f'\n\n'
+        DESCRIPTION += '\n\n'
 
         for module, ex in unavailable:
             DESCRIPTION += (f'WARNING: pytmc {module!r} is unavailable due to:'

--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -119,14 +119,14 @@ def summary(tsproj_project, use_markdown=False, show_all=False,
         for i, plc in enumerate(project.plcs, 1):
             util.heading(f'PLC Project ({i}): {plc.project_path.stem}')
             print(f'    Project root: {proj_root}')
-            print(f'    Project path:',
+            print('    Project path:',
                   plc.project_path.resolve().relative_to(proj_root))
-            print(f'    TMC path:    ',
+            print('    TMC path:    ',
                   plc.tmc_path.resolve().relative_to(proj_root))
             print(f'    AMS ID:       {plc.ams_id}')
             print(f'    IP Address:   {plc.target_ip} (* based on AMS ID)')
             print(f'    Port:         {plc.port}')
-            print(f'')
+            print()
             proj_info = [
                 ('Source files', [pathlib.Path(fn).relative_to(proj_root)
                                   for fn in plc.source_filenames]),

--- a/pytmc/bin/util.py
+++ b/pytmc/bin/util.py
@@ -50,7 +50,7 @@ def text_block(text, indent=4, markdown_language=None, *, file=sys.stdout):
     if markdown_language is not None:
         print(f'```{markdown_language}', file=file)
         print(text, file=file)
-        print(f'```', file=file)
+        print('```', file=file)
     else:
         for line in text.splitlines():
             print(' ' * indent, line, file=file)

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -605,7 +605,8 @@ def record_packages_from_symbol(symbol, *, pragma: str = 'pytmc',
         for chain in chains_from_symbol(symbol, pragma=pragma,
                                         allow_no_pragma=allow_no_pragma):
             try:
-                yield RecordPackage.from_chain(symbol.module.ads_port, chain=chain)
+                yield RecordPackage.from_chain(symbol.module.ads_port,
+                                               chain=chain)
             except Exception as ex:
                 if yield_exceptions:
                     yield type(ex)(f"Symbol {symbol.name} "


### PR DESCRIPTION
* Catch overall symbol-level pragma parsing failures and annotate with symbol name
* Catch chain-level failures and annotate with chain names

Result looks like this:
```
ERROR:pytmc.bin.db:Error creating record: Symbol GVL_FEE_Device.MR1K4_SOMS_PIP_01 failure: Found invalid pragma line(s):
--> | MR1K4_SOMS_PIP_01
ERROR:pytmc.bin.db:Error creating record: Symbol GVL_FEE_Device.ST1K4_TEST_PIP_01 failure: Found invalid pragma line(s):
--> | ST1K4_TEST_PIP_01
ERROR:pytmc.bin.db:Error creating record: Symbol GVL_FEE_Device.ST2K4_BCS_PIP_01 failure: Found invalid pragma line(s):
--> | ST2K4_BCS_PIP_01
ERROR:pytmc.bin.db:Error creating record: Symbol GVL_FEE_Device.ST3K4_PPS_PIP_01 failure: Found invalid pragma line(s):
--> | ST3K4_PPS_PIP_01
ERROR:pytmc.bin.db:Error creating record: Symbol GVL_FEE_Device.PC4K4_XTES_PIP_01 failure: Found invalid pragma line(s):
--> | PC4K4_XTES_PIP_01
```

The output would look better if there were multiple lines, something like:
```
    line1
    line2
--> bad line
```
