### PR TITLE
Tweaks for handling the DESC field

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -1,10 +1,9 @@
 """
 Record generation and templating
 """
+import jinja2
 import logging
 import pytmc
-
-from jinja2 import Environment, PackageLoader
 
 from typing import Optional
 
@@ -15,6 +14,12 @@ from .default_settings.unified_ordered_field_list import unified_lookup_list
 
 logger = logging.getLogger(__name__)
 MAX_ARCHIVE_ELEMENTS = 1024
+
+_default_jinja_env = jinja2.Environment(
+    loader=jinja2.PackageLoader("pytmc", "templates"),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
 
 
 def _truncate_middle(string, max_length):
@@ -58,15 +63,7 @@ class EPICSRecord:
         if 'fields' not in self.archive_settings:
             self.archive_settings = {}
 
-        # Load jinja templates
-        self.jinja_env = Environment(
-            loader=PackageLoader("pytmc", "templates"),
-            trim_blocks=True,
-            lstrip_blocks=True,
-        )
-        self.record_template = self.jinja_env.get_template(
-            self.template
-        )
+        self.record_template = _default_jinja_env.get_template(self.template)
 
     def update_autosave_from_pragma(self, config):
         """

--- a/pytmc/templates/asyn_standard_record.jinja2
+++ b/pytmc/templates/asyn_standard_record.jinja2
@@ -1,4 +1,7 @@
 record({{record.record_type}}, "{{record.pvname}}") {
+{% if record.long_description %}
+  # {{ record.long_description }}
+{% endif %}
 {% for alias in record.aliases %}
   alias("{{alias}}")
 {% endfor %}


### PR DESCRIPTION
Automatic "middle" truncation of DESC field has been in place for the default description, as follows:

`GVL_GMD.fb_EM1K0_GMD_PRT_40.stPump.i_xAlarmOK` would become a description of `ads:GVL_GMD.fb_EM1K0...stPump.i_xAlarmOK` to fit within the 40 character field limit. This PR removes the `ads:` prefix, which further shortens the displayable characters.

The above was not generically applied to user-specified descriptions. This caused many instances of db parsing failures on IOC boot.

Rather than do as suggested in #196 making this either a warning/error, the DESC field itself is truncated silently, but also included in full-form as a comment in the database file.

Before
--------
```
record(bi, "EM1K0:GMD:PRT:40:ALARM_OK_RBV") {
  field(DESC, "ads:GVL_GMD.fb_EM1K0...stPump.i_xAlarmOK")
  ...
}
```

After
--------
```
record(bi, "EM1K0:GMD:PRT:40:ALARM_OK_RBV") {
  # GVL_GMD.fb_EM1K0_GMD_PRT_40.stPump.i_xAlarmOK
  field(DESC, "GVL_GMD.fb_EM1K0_GMD...stPump.i_xAlarmOK")
  ...
}
```

Closes #196 