### PR TITLE
ENH: symbol-less data type record information

### DIFF
--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -123,7 +123,7 @@ def list_types(plc, pragma='pv: @(PREFIX)', filter_types=None,
         print('* TMC unavailable to show types', file=file)
         return
 
-    for data_type in tmc.find(parser.DataType):
+    for data_type in sorted(tmc.find(parser.DataType), key=lambda dt: dt.name):
         if filter_types:
             if not any(fnmatch.fnmatch(data_type.name, filter_type)
                    for filter_type in filter_types):

--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -186,6 +186,10 @@ def enumerate_types(tmc, pragma='pv: @(PREFIX)', filter_types=None):
     """
     for data_type in sorted(tmc.find(parser.DataType),
                             key=lambda dt: dt.qualified_type):
+        base_type = data_type.base_type
+        if base_type and not base_type.is_complex_type:
+            continue
+
         if filter_types:
             if not any(fnmatch.fnmatch(data_type.name, filter_type)
                        for filter_type in filter_types):

--- a/pytmc/bin/summary.py
+++ b/pytmc/bin/summary.py
@@ -12,7 +12,6 @@ import sys
 from .. import parser, pragmas
 from . import util
 
-
 DESCRIPTION = __doc__
 
 
@@ -126,7 +125,7 @@ def list_types(plc, pragma='pv: @(PREFIX)', filter_types=None,
     for data_type in sorted(tmc.find(parser.DataType), key=lambda dt: dt.name):
         if filter_types:
             if not any(fnmatch.fnmatch(data_type.name, filter_type)
-                   for filter_type in filter_types):
+                       for filter_type in filter_types):
                 continue
 
         symbol = pragmas.make_fake_symbol_from_data_type(
@@ -146,7 +145,7 @@ def list_types(plc, pragma='pv: @(PREFIX)', filter_types=None,
             record.pvname
             for record in sorted((record for pkg in packages
                                   for record in pkg.records),
-                key=lambda r: r.pvname)
+                                 key=lambda r: r.pvname)
         ]
         util.text_block('\n'.join(block))
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -11,9 +11,8 @@ import types
 import lxml
 import lxml.etree
 
-from .code import (get_pou_call_blocks, program_name_from_declaration,
-                   variables_from_declaration, determine_block_type)
-
+from .code import (determine_block_type, get_pou_call_blocks,
+                   program_name_from_declaration, variables_from_declaration)
 
 # Registry of all TwincatItem-based classes
 TWINCAT_TYPES = {}
@@ -708,6 +707,13 @@ class DataType(_TmcItem):
         if 'Namespace' in name_attrs:
             return f'{name_attrs["Namespace"]}.{self.name}'
         return self.name
+
+    @property
+    def base_type(self):
+        base_type = getattr(self, 'BaseType', [None])[0]
+        if base_type is None:
+            return None
+        return self.tmc.get_data_type(base_type.text)
 
     @property
     def is_complex_type(self):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -843,6 +843,10 @@ class Property(_TmcItem):
         return f'<Property {self.key}={self.value!r}>'
 
 
+class DataArea(_TmcItem):
+    '[TMC] Container that holds symbols'
+
+
 class BuiltinDataType:
     '[TMC] A built-in data type such as STRING, INT, REAL, etc.'
     def __init__(self, typename, *, length=1):
@@ -1316,6 +1320,26 @@ class _ArrayItemProxy:
 
     def __setattr__(self, attr, value):
         return setattr(self.__dict__['item'], attr, value)
+
+
+def _make_fake_item(name, parent=None, item_name=None, *, text=None,
+                    attrib=None):
+    """Make a fake TwincatItem, for debugging/testing purposes."""
+    cls = TWINCAT_TYPES[name]
+    filename = (parent.filename
+                if parent is not None
+                else pathlib.Path(__file__))
+
+    attrib = attrib or {}
+    if 'name' not in attrib:
+        attrib['name'] = item_name or name
+
+    elem = lxml.etree.Element(cls.__name__, attrib=attrib)
+    elem.text = text or ''
+    item = cls(element=elem,
+               name=attrib['name'],
+               parent=parent, filename=filename)
+    return item
 
 
 def case_insensitive_path(path):

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -1,16 +1,15 @@
 """
 Record generation and templating
 """
-import jinja2
 import logging
-import pytmc
-
+from collections import ChainMap, OrderedDict
 from typing import Optional
 
-from collections import ChainMap, OrderedDict
+import jinja2
+
+import pytmc
 
 from .default_settings.unified_ordered_field_list import unified_lookup_list
-
 
 logger = logging.getLogger(__name__)
 MAX_ARCHIVE_ELEMENTS = 1024
@@ -77,7 +76,7 @@ class EPICSRecord:
 
     def __init__(self, pvname, record_type, direction, fields=None,
                  template=None, autosave=None, aliases=None,
-                 archive_settings=None):
+                 archive_settings=None, package=None):
         self.pvname = pvname
         self.record_type = record_type
         self.direction = direction
@@ -85,6 +84,7 @@ class EPICSRecord:
         self.aliases = list(aliases) if aliases is not None else []
         self.template = template or 'asyn_standard_record.jinja2'
         self.autosave = dict(autosave) if autosave else {}
+        self.package = package
         self.archive_settings = (dict(archive_settings)
                                  if archive_settings else {})
 
@@ -405,6 +405,7 @@ class TwincatTypeRecordPackage(RecordPackage):
                              autosave=self.autosave_defaults.get('input'),
                              aliases=aliases,
                              archive_settings=self.archive_settings,
+                             package=self,
                              )
 
         # Set a default description to the tcname
@@ -448,6 +449,7 @@ class TwincatTypeRecordPackage(RecordPackage):
                              autosave=self.autosave_defaults.get('output'),
                              aliases=self.aliases,
                              archive_settings=self.archive_settings,
+                             package=self,
                              )
 
         # Set a default description to the tcname

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -28,7 +28,7 @@ def test_help_module(monkeypatch, subcommand):
 
 def test_summary(project_filename):
     summary_main(project_filename, show_all=True, show_code=True,
-                 use_markdown=True)
+                 use_markdown=True, show_types=True, filter_types=['*'])
 
 
 @pytest.fixture()


### PR DESCRIPTION
Still requires `.tmc` file, but may help with validation of pcdsdevices PRs.

Sample (clipped) output:
```
$ pytmc summary L2SIVacuumLib.tsproj --types --filter-type ST_* --filter-type FB_*

...clipped...

Data type ST_FFVeto
-------------------

     $(PREFIX):Activate
     $(PREFIX):Activate_RBV
     $(PREFIX):Active_RBV
     $(PREFIX):Deactivate
     $(PREFIX):Deactivate_RBV
     $(PREFIX):Duration
     $(PREFIX):Duration_RBV
     $(PREFIX):ElapsedTime_RBV

...clipped...

Data type FB_MKS422
-------------------

     $(PREFIX):AT_VAC_RBV
     $(PREFIX):DISC_ACTIVE_RBV
     $(PREFIX):HV_DIS_DO_RBV
     $(PREFIX):HV_ON_RBV
     $(PREFIX):HV_SW
     $(PREFIX):HV_SW_RBV
     $(PREFIX):ILK_OK_RBV
     $(PREFIX):LOGGER_RBV
     $(PREFIX):PRESS_AI_RBV
     $(PREFIX):PRESS_OK_RBV
     $(PREFIX):PRESS_RBV
     $(PREFIX):PRO_SP
     $(PREFIX):PRO_SP_RBV
     $(PREFIX):SP_HYS
     $(PREFIX):SP_HYS_RBV
     $(PREFIX):STATE_RBV
     $(PREFIX):VAC_SP
     $(PREFIX):VAC_SP_RBV
```