### PR TITLE
FIX: any error makes the sub-command unavailable

### DIFF
--- a/pytmc/bin/pytmc.py
+++ b/pytmc/bin/pytmc.py
@@ -32,7 +32,7 @@ def _build_commands():
     for module in sorted(MODULES):
         try:
             mod = _try_import(module)
-        except ImportError as ex:
+        except Exception as ex:
             unavailable.append((module, ex))
         else:
             result[module] = (mod.build_arg_parser, mod.main)


### PR DESCRIPTION
Closes #201, as I can only assume it's what @n-wbrown ran into.
Saw this on travis:
`qtpy.PythonQtError: No Qt bindings could be found` which apparently does not subclass `ImportError`.