### PR TITLE
ENH/REF: data types by guid, falling back to qualified type name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.4.1
+    rev: 5.4.2
     hooks:
     -   id: isort

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,11 @@ Fixes
 
 * Relaxed end-of-pragma-line handling (any combination of ``;`` and newline are
   all accepted).
+* Reworked XTI file loading for "devices" and "boxes".  This aims to be more
+  compatible with TwinCAT, which does not always relocate XTI files to be in
+  the correct hierarchical directory location.  It pre-loads all XTI files, and
+  when the project is fully loaded, it dereferences XTI files based on a key
+  including ``class``, ``filename``, and a small PLC-unique ``identifier``.
 * Better handling of data types in the project parser. Now supports data type
   GUIDs, when available, for data type disambiguation.  Note that these are not
   always present.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,32 @@
  Release History
 =================
 
+v2.7.5 (2020-08-31)
+===================
+
+
+Fixes
+-----
+
+* Relaxed end-of-pragma-line handling (any combination of ``;`` and newline are
+  all accepted).
+* Better handling of data types in the project parser. Now supports data type
+  GUIDs, when available, for data type disambiguation.  Note that these are not
+  always present.
+* Better handling of references, pointers, and pointer depth.
+
+Development
+-----------
+
+* ``pytmc db --debug`` allows developers to more easily target exceptions
+  raised when generating database files.
+* Added more memory layout information for the benefit of other utilities such
+  as ``ads-async``. Its ADS server implementation in conjunction with pytmc may
+  be a good source of information regarding PLC memory layout in the future.
+* Started adding some annotations for clarity.  May retroactively add more as
+  time permits.
+
+
 v2.7.1 (2020-08-18)
 ===================
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -1013,9 +1013,8 @@ class DataType(_TmcItem):
 
     def walk(self, condition=None):
         if self.is_enum:
-            # Ensure something is yielded for this type - it doesn't
-            # appear possible to have SubItems or use ExtendsType
-            # in this case.
+            # Ensure something is yielded for this type - it doesn't appear
+            # possible to have SubItems or use ExtendsType in this case.
             yield []
             return
 

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -145,8 +145,18 @@ def _determine_path(base_path, name, class_hint):
 
 
 class TwincatItem:
-    _load_path_hint = ''
-    _lazy_load = False
+    _load_path_hint: str = ''
+    _lazy_load: bool = False
+    _children: typing.List['TwincatItem']
+    attributes: typing.Dict[str, str]
+    children: types.SimpleNamespace
+    comments: typing.List[str]
+    element: lxml.etree.Element
+    filename: pathlib.Path
+    name: str
+    parent: 'TwincatItem'
+    tag: str
+    text: typing.Optional[str]
 
     def __init__(self, element, *, parent=None, name=None, filename=None):
         '''
@@ -956,7 +966,7 @@ class DataType(_TmcItem):
         return getattr(self.array_info, 'array_bounds', None)
 
     @property
-    def friendly_name(self):
+    def summary_type_name(self):
         summary = self.name
         array_bounds = self.array_bounds
         if array_bounds:
@@ -1064,7 +1074,7 @@ class BoundDataType:
         )
 
     @property
-    def friendly_name(self):
+    def summary_type_name(self):
         summary = self.name
         if self.is_pointer:
             summary = 'POINTER TO ' + summary
@@ -1223,7 +1233,7 @@ class BuiltinDataType:
         return self.name
 
     @property
-    def friendly_name(self):
+    def summary_type_name(self):
         if self.length > 1:
             return f'{self.name}({self.length})'
         return self.name
@@ -1361,7 +1371,7 @@ class Symbol(_TmcItem):
 
     @property
     def summary_type_name(self):
-        return self.data_type.friendly_name
+        return self.data_type.summary_type_name
 
 
 class Symbol_DUT_MotionStage(Symbol):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -907,7 +907,7 @@ class ExtendsType(_TmcItem):
         """
         Namespace of the data type.
         """
-        return self.attributes.get('namespace', None)
+        return self.attributes.get('Namespace', None)
 
     @property
     def guid(self):
@@ -1096,6 +1096,9 @@ class BoundDataType:
 
     def __getattr__(self, attr):
         return getattr(self.data_type, attr)
+
+    def walk(self, condition=None):
+        yield from self.data_type.walk(condition=condition)
 
 
 class Name(_TmcItem):

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -413,10 +413,10 @@ class TcModuleClass(_TwincatProjectSubItem):
     '[TMC] The top-level TMC file'
     DataTypes: list
 
-    def get_data_type(self, type_name, *, include_project=True):
-        """Get a data type by name (or GUID)."""
+    def get_data_type(self, ref, *, include_project=True):
+        """Get a data type by name, GUID, or BaseType."""
         proj = self.find_ancestor(TcSmProject) if include_project else None
-        return get_data_type_by_reference(self.base_type, (self.tmc, proj))
+        return get_data_type_by_reference(ref, (self, proj))
 
     def create_data_area(self, module_index=0):
         """

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -425,15 +425,6 @@ class TcModuleClass(_TwincatProjectSubItem):
     '[TMC] The top-level TMC file'
     DataTypes: typing.List['DataTypes']
 
-    def get_data_type(self, ref, *, include_project=True, array_info=None,
-                      reference=None, pointer=None):
-        """Get a data type by name, GUID, or BaseType."""
-        proj = self.find_ancestor(TcSmProject) if include_project else None
-        return get_data_type_by_reference(
-            ref, (self, proj), array_info=array_info,
-            reference=reference, pointer=pointer
-        )
-
     def create_data_area(self, module_index=0):
         """
         Create a fake DataArea in a given parsed TcModuleClass (tmc).
@@ -518,12 +509,6 @@ class TcSmProject(TwincatItem):
     def plcs_by_link_name(self):
         'The virtual PLC projects in a dictionary keyed by link name'
         return {plc.link_name: plc for plc in self.plcs}
-
-    def get_data_type(self, type_name, *, array_info=None, reference=False,
-                      pointer=False):
-        """Project-level data types exist alongside tmc-defined data types."""
-        return get_data_type_by_reference(type_name, array_info=array_info,
-                                          reference=reference, pointer=pointer)
 
 
 def get_data_type_by_reference(

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -535,10 +535,13 @@ class SingularChain:
                 f'data_type={self.data_type!r})')
 
 
-def find_pytmc_symbols(tmc, allow_no_pragma=False):
+def find_pytmc_symbols(tmc, allow_no_pragma=False, include_structs=False):
     'Find all symbols in a tmc file that contain pragmas'
     for symbol in tmc.find(parser.Symbol):
         if has_pragma(symbol) or allow_no_pragma:
+            if not include_structs and symbol.data_type.is_complex_type:
+                continue
+
             if symbol.name.count('.') == 1:
                 yield symbol
 

--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -165,6 +165,16 @@ class RecordPackage:
 
         self._parse_config(self.config)
 
+    def __repr__(self):
+        items = {
+            attr: getattr(self, attr, None)
+            for attr in ('tcname', 'pvname', 'long_description',
+                         'linked_to_pv')
+        }
+        info = ', '.join(f'{k}={v!r}' for k, v in items.items()
+                         if v)
+        return f"{self.__class__.__name__}({info})"
+
     def _parse_config(self, config):
         'Parse the chain configuration'
         if config is None:

--- a/pytmc/tests/test_integrations.py
+++ b/pytmc/tests/test_integrations.py
@@ -2,6 +2,7 @@
 Collections of higher level tests that don't fit cleanly into unit or module
 test files.
 """
+
 import pytest
 
 from pytmc import parser
@@ -58,7 +59,7 @@ def test_allow_no_pragma():
         show_error_context=True, allow_no_pragma=True
     )
     good_records = 129
-    total_records = 976
+    total_records = 1002
 
     assert good_records == len(records)
     assert good_records == len(list(x.valid for x in records if x.valid))


### PR DESCRIPTION
* Some GUIDs appear to be implicitly defined (the data type `GUID` itself, `OTCID`, maybe others?)

<details>
<summary>
Fixes at least some instances of missing symbols (hence the updated test)
</summary>

```
> TwinCAT_SystemInfoVarList._AppInfo.AdsPort
> TwinCAT_SystemInfoVarList._AppInfo.AppName
> TwinCAT_SystemInfoVarList._AppInfo.AppTimestamp
> TwinCAT_SystemInfoVarList._AppInfo.BSODOccured
> TwinCAT_SystemInfoVarList._AppInfo.BootDataLoaded
> TwinCAT_SystemInfoVarList._AppInfo.Flags
> TwinCAT_SystemInfoVarList._AppInfo.KeepOutputsOnBP
> TwinCAT_SystemInfoVarList._AppInfo.LicensesPending
> TwinCAT_SystemInfoVarList._AppInfo.LoggedIn
> TwinCAT_SystemInfoVarList._AppInfo.ObjId
> TwinCAT_SystemInfoVarList._AppInfo.OldBootData
> TwinCAT_SystemInfoVarList._AppInfo.OnlineChangeCnt
> TwinCAT_SystemInfoVarList._AppInfo.ProjectName
> TwinCAT_SystemInfoVarList._AppInfo.ShutdownInProgress
> TwinCAT_SystemInfoVarList._AppInfo.TComSrvPtr
> TwinCAT_SystemInfoVarList._AppInfo.TaskCnt
> TwinCAT_SystemInfoVarList._TaskInfo.AdsPort
> TwinCAT_SystemInfoVarList._TaskInfo.CycleCount
> TwinCAT_SystemInfoVarList._TaskInfo.CycleTime
> TwinCAT_SystemInfoVarList._TaskInfo.CycleTimeExceeded
> TwinCAT_SystemInfoVarList._TaskInfo.DcTaskTime
> TwinCAT_SystemInfoVarList._TaskInfo.FirstCycle
> TwinCAT_SystemInfoVarList._TaskInfo.InCallAfterOutputUpdate
> TwinCAT_SystemInfoVarList._TaskInfo.LastExecTime
> TwinCAT_SystemInfoVarList._TaskInfo.ObjId
> TwinCAT_SystemInfoVarList._TaskInfo.Priority
> TwinCAT_SystemInfoVarList._TaskInfo.RTViolation
> TwinCAT_SystemInfoVarList._TaskInfo.TaskName
```
</details>