### PR TITLE
REF/FIX: box file loading, again

### DIFF
--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -1390,7 +1390,17 @@ class Io(TwincatItem):
         xti_files = {}
 
         for xti_filename in io_dir.glob('**/*.xti'):
-            xti = parse(xti_filename)
+            try:
+                xti = parse(xti_filename)
+            except Exception as ex:
+                logger.warning(
+                    '(Pre-loading XTI file) Failed: %s (%s). If this file is '
+                    'referenced in the project, this may cause the project to '
+                    'fail loading.  If not, this can be ignored.',
+                    xti_filename.name, ex
+                )
+                continue
+
             try:
                 key = get_key(xti_filename, xti)
             except Exception as ex:


### PR DESCRIPTION
I think this pre-loading and indexing of XTI files will prove a more reliable method.

It loads master on these:
```
lcls-plc-crixs-motion
lcls-plc-crixs-vac
lcls-plc-kfe-arbiter
lcls-plc-kfe-gmd-vac
lcls-plc-kfe-motion
lcls-plc-kfe-rix-motion
lcls-plc-kfe-rix-vac
lcls-plc-kfe-vac
lcls-plc-kfe-xgmd-vac
lcls-plc-lfe-arbiter
lcls-plc-lfe-gem
lcls-plc-lfe-motion
lcls-plc-lfe-motion-kmono
lcls-plc-lfe-optics
lcls-plc-lfe-vac
lcls-plc-liquid-jet
lcls-plc-roving-spectrometer
lcls-plc-tmo-motion
lcls-plc-vls-vac
```

With 2 hash key clashes:

<details>

```
WARNING:pytmc.parser:Found multiple potential matches with the same key: (<class 'pytmc.parser.Box'>, '32', 'box 32 (el6692).xti') => /Users/klauer/docs/Repos/plcs/lcls-plc-kfe-arbiter/Arbiter/_Config/IO/Device 1 (EtherCAT)/Box 28 (CU1128)/Box 32 (EL6692).xti (choosing /Users/klauer/docs/Repos/plcs/lcls-plc-kfe-arbiter/Arbiter/_Config/IO/Device 1 (EtherCAT)/Box 18 (CU1128)/Box 32 (EL6692).xti)

WARNING:pytmc.parser:Found multiple potential matches with the same key: (<class 'pytmc.parser.Box'>, '32', 'box 32 (el6692).xti') => /Users/klauer/docs/Repos/plcs/lcls-plc-lfe-arbiter/Arbiter/_Config/IO/Device 1 (EtherCAT)/Box 28 (CU1128)/Box 32 (EL6692).xti (choosing /Users/klauer/docs/Repos/plcs/lcls-plc-lfe-arbiter/Arbiter/_Config/IO/Device 1 (EtherCAT)/Box 18 (CU1128)/Box 32 (EL6692).xti)
```
</details>

The clashing keys _appear_ to be an error of version control / visual studio and not pytmc's loading mechanism.

And warnings due to files that were also incorrectly in the repository, I believe:

<details>

```
WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EP4374-0002_05_00.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EP4374-0002_05_00.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EK1100_02_00.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EK1100_02_00.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EK1200_00_00.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EK1200_00_00.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EK1100_04_00.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EK1100_04_00.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EP7041-0002_05_02.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EP7041-0002_05_02.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EK1100_01_00.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EK1100_01_00.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EP5101-0011_05_01.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EP5101-0011_05_01.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.

WARNING:pytmc.parser:(Pre-loading XTI file) Failed: EK1100_03_00.xti ([Errno 2] No such file or directory: '/Users/klauer/docs/Repos/plcs/lcls-plc-kfe-gmd-vac/plc/plc-kfe-gmd-vac/_Config/IO/Device 1 (EtherCAT)/EK1100_03_00.xti'). If this file is referenced in the project, this may cause the project to fail loading.  If not, this can be ignored.
```
</details>