### PR TITLE
FIX: fix autosave pass1 by setting PINI=YES

### DIFF
--- a/pytmc/record.py
+++ b/pytmc/record.py
@@ -125,6 +125,19 @@ class EPICSRecord:
                     fields = set(config[config_key].split(' '))
                     self.autosave[record_key] = fields
 
+    def update_pini_for_autosave(self):
+        """
+        Set PINI=1 if VAL is autosaved at pass1.
+
+        This is a bandaid fix for unexplained behavior where the
+        autosave pass1 does not send values to the PLC unless
+        PINI=1.
+
+        This is intended to be called for output records.
+        """
+        if 'VAL' in self.autosave['pass1']:
+            self.fields['PINI'] = 1
+
     def render(self, sort: bool = True):
         """Render the provided template"""
         for field, value in list(self.fields.items()):
@@ -509,6 +522,7 @@ class TwincatTypeRecordPackage(RecordPackage):
         _update_description(record, self.chain.tcname)
 
         record.update_autosave_from_pragma(self.config)
+        record.update_pini_for_autosave()
         return record
 
     @property


### PR DESCRIPTION
closes #235 

This is a workaround fix for autosave pass1 not behaving as expected for records where PINI=0

Implementation:
- Add a method `update_pini_for_autosave` on `EPICSRecord` with an appropriate docstring
- Call this method when creating output records

With the goal of being able to cleanly remove this method if we figure out why the expected behavior did not work at ads-ioc in https://github.com/pcdshub/ads-ioc/issues/65

Resulting diff on my test IOC (extended to show the full record):
```
$ git diff
diff --git a/iocBoot/ioc-tc-mot-example/tc_mot_example.db b/iocBoot/ioc-tc-mot-example/tc_mot_example.db
index 319a356..cd3628b 100644
--- a/iocBoot/ioc-tc-mot-example/tc_mot_example.db
+++ b/iocBoot/ioc-tc-mot-example/tc_mot_example.db
@@ -13,6 +13,7 @@ record(ai, "PLC:TST:PASS1_RBV") {

 record(ao, "PLC:TST:PASS1") {
   field(DESC, "Main.fAutoPass1")
+  field(PINI, "1")
   field(DTYP, "asynFloat64")
   field(OUT, "@asyn($(PORT),0,1)ADSPORT=851/Main.fAutoPass1=")
   field(PREC, "3")
   info(autosaveFields, "VAL")
   info(autosaveFields_pass0, "PREC")
   info(archive, "VAL")
 }
```