### PR TITLE
ENH: subitem pragma support

### DIFF
--- a/docs/pragma_usage.rst
+++ b/docs/pragma_usage.rst
@@ -468,3 +468,58 @@ autosaving:
       ...
       info(autosaveFields_pass0, "VAL DESC")
    }
+
+
+Sub-Items
+.........
+
+There is a special syntax to pragma a member of a structure differently
+depending on the instance.
+
+Given this example function block:
+
+.. code-block:: none
+
+    FUNCTION_BLOCK FB_Test
+    VAR
+        {attribute 'pytmc' := 'pv: variable1'}
+        variable1 : LREAL := 0.0;
+
+        {attribute 'pytmc' := 'pv: variable2'}
+        variable2 : LREAL := 0.0;
+    END_VAR
+    END_FUNCTION_BLOCK
+
+Adding these pragmas to two instances:
+
+.. code-block:: none
+
+    {attribute 'pytmc' := '
+        pv: TEST:A
+        variable1.io: i
+        variable2.io: i
+    '}
+    fbTestA : FB_Test;
+
+    {attribute 'pytmc' := '
+        pv: TEST:B
+        variable1.io: io
+        variable2.io: io
+    '}
+    fbTestB : FB_Test;
+
+The above would result in two different ``io`` settings for
+``fbTestA.variable1`` and ``fbTestB.variable1``.
+
+There are some limitations on this preliminary feature. You may not add or
+change the following fields for now:
+
+.. code-block:: none
+
+    pv
+    link
+    field
+
+
+The primary use case is expected to be ``array``, to limit the number of array
+instances generated with hard-coded upper bounds on encapsulated structures.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,12 +8,17 @@ v2.8.0 (2020-??-??)
 Enhancements
 ------------
 
+* Add support for externally adding pragmas to members of structures and
+  function blocks.
 * Add support for partial pragmas of array elements.
+* Added text filter in ``pytmc debug`` dialog.
 
 Fixes
 -----
 
-* Record names now displaying correctly in ``pytmc debug`` dialog
+* Record names now displaying correctly in ``pytmc debug`` dialog.
+* ``pytmc debug`` no longer fails when it encounters types that extend
+  built-in data types by way of ``ExtendsType``.
 
 v2.7.7 (2020-11-17)
 ===================

--- a/pytmc/bin/debug.py
+++ b/pytmc/bin/debug.py
@@ -138,8 +138,10 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.item_view_type.addItem('Chains w/o Records')
         self.item_view_type.currentTextChanged.connect(self._update_view_type)
         self.item_list = QtWidgets.QListWidget()
+        self.item_list_filter = QtWidgets.QLineEdit()
 
         self.left_layout.addWidget(self.item_view_type)
+        self.left_layout.addWidget(self.item_list_filter)
         self.left_layout.addWidget(self.item_list)
 
         # Right part of the window
@@ -182,6 +184,14 @@ class TmcSummary(QtWidgets.QMainWindow):
         self.item_selected.connect(self._update_chain_info)
         self.item_selected.connect(self._update_record_text)
 
+        def set_filter(text):
+            text = text.strip().lower()
+            for idx in range(self.item_list.count()):
+                item = self.item_list.item(idx)
+                item.setHidden(bool(text and text not in item.text().lower()))
+
+        self.item_list_filter.textEdited.connect(set_filter)
+
         self._update_item_list()
 
     def _item_selected(self, current, previous):
@@ -202,6 +212,7 @@ class TmcSummary(QtWidgets.QMainWindow):
         chain = record.chain
 
         self.config_info.clear()
+        self.item_list_filter.setText('')
         self.config_info.setRowCount(len(chain.chain))
 
         def add_dict_to_table(row: int, d: dict):

--- a/pytmc/bin/stcmd.py
+++ b/pytmc/bin/stcmd.py
@@ -12,11 +12,9 @@ import pathlib
 
 import jinja2
 
-from . import db, util
 from .. import pragmas
-
-from ..parser import parse, Symbol, separate_by_classname, NC
-
+from ..parser import NC, Symbol, parse, separate_by_classname
+from . import db, util
 
 DESCRIPTION = __doc__
 logger = logging.getLogger(__name__)
@@ -138,7 +136,7 @@ def get_name(obj, user_config):
         item_to_config = dict(item_and_config[0])
         config = pragmas.squash_configs(*item_to_config.values())
         # PV name specified in the pragma - use it as-is
-        if 'pv' in config:
+        if config.get('pv'):
             pv = delim.join(config['pv'])
             if delim in pv:
                 pv_parts = pv.split(delim)

--- a/pytmc/parser.py
+++ b/pytmc/parser.py
@@ -928,6 +928,11 @@ class ExtendsType(_TmcItem):
         namespace = self.namespace
         return f'{namespace}.{self.text}' if namespace else self.text
 
+    @property
+    def type_name(self):
+        """The type name, without a namespace."""
+        return self.text
+
 
 class BaseType(Type):
     '[TMC] A reference to the data type of a symbol'

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -678,12 +678,12 @@ def record_packages_from_symbol(symbol, *, pragma: str = 'pytmc',
             except Exception as ex:
                 if yield_exceptions:
                     yield type(ex)(f"Symbol {symbol.name} "
-                                   f"chain: {chain.tcname}: {ex.args[0]}")
+                                   f"chain: {chain.tcname}: {ex}")
                 else:
                     raise
     except Exception as ex:
         if yield_exceptions:
-            yield type(ex)(f"Symbol {symbol.name} failure: {ex.args[0]}")
+            yield type(ex)(f"Symbol {symbol.name} failure: {ex}")
         else:
             raise
 

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -2,6 +2,7 @@
 This file contains the objects for taking in pytmc-parsed TMC files and
 generating Python-level configuration information.
 """
+import copy
 import itertools
 import logging
 import math
@@ -49,6 +50,14 @@ _ARCHIVE_RE = re.compile(
     flags=re.IGNORECASE
 )
 ARCHIVE_DEFAULT = {'frequency': 1, 'seconds': 1, 'method': 'scan'}
+
+# Special, reserved keys:
+SUBITEM = '_subitem_'
+PRAGMA = '_pragma_'
+DISALLOWED_SUBITEMS = {'pv', SUBITEM, PRAGMA}
+
+# Default for array index expansion:
+EXPAND_DEFAULT = ':%.2d'
 
 
 def split_pytmc_pragma(pragma_text):
@@ -158,7 +167,14 @@ def separate_configs_by_pv(config_lines):
         yield pv, config
 
 
-def dictify_config(conf, array_index=None, expand_default=':%.2d'):
+def get_array_suffix(config, array_index, *, default=EXPAND_DEFAULT):
+    '''
+    Return array index suffix based on the expand settings in the config.
+    '''
+    return config.get('expand', default) % array_index
+
+
+def dictify_config(raw_conf, array_index=None):
     '''
     Make a raw config list into an easier-to-use dictionary
 
@@ -175,18 +191,44 @@ def dictify_config(conf, array_index=None, expand_default=':%.2d'):
          'field': {'fieldname': 'value'}}
     '''
 
+    title_tag_pairs = [(item['title'], item['tag']) for item in raw_conf]
+
     fields = {
-        item['tag']['f_name']: item['tag']['f_set']
-        for item in conf
-        if item['title'] == 'field'
+        tag['f_name']: tag['f_set']
+        for title, tag in title_tag_pairs
+        if title == 'field'
     }
-    config = {item['title']: item['tag']
-              for item in conf}
+
+    config = {
+        title: tag
+        for title, tag in title_tag_pairs
+        if '.' not in title  # Handle subitem entries specially
+    }
+
     if fields:
         config['field'] = fields
 
     if array_index is not None:
-        config['pv'] += config.get('expand', expand_default) % array_index
+        config['pv'] += get_array_suffix(config, array_index)
+
+    def add_subitem(d, key, value):
+        if '.' in key:
+            # The first a.b.c.pragma indicate the sub-(sub-) item for 'pragma':
+            child, remainder = key.split('.', 1)
+            if child not in d:
+                d[child] = {PRAGMA: []}
+            add_subitem(d[child], remainder, value)
+        else:
+            if key in DISALLOWED_SUBITEMS:
+                raise ValueError(f'Unsupported pragma key in subitem: {key}')
+            # The final key is a pytmc-supported pragma:
+            d[PRAGMA].append((key, value))
+
+    for title, tag in title_tag_pairs:
+        if '.' in title:
+            if SUBITEM not in config:
+                config[SUBITEM] = {}
+            add_subitem(config[SUBITEM], title, tag)
 
     return config
 
@@ -216,29 +258,38 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
     -------
     tuple
         Tuple of tuples. See description above.
-
     '''
     result = []
 
-    def dictify_scalar(item):
-        for pvname, config in separate_configs_by_pv(
-                split_pytmc_pragma('\n'.join(pragmas))):
-            yield (item, dictify_config(config))
+    def dictify_scalar(item, pvname, config):
+        yield item, copy.deepcopy(config)
 
-    def dictify_complex_array(item):
+    def dictify_complex_array(item, pvname, config):
         low, high = item.array_info.bounds
         expand_digits = math.floor(math.log10(high)) + 2
-        expand_default = f':%.{expand_digits}d'
-        for pvname, config in separate_configs_by_pv(
-                split_pytmc_pragma('\n'.join(pragmas))):
+        array_element_pragma = config.get('array', '')
+        for idx in parse_array_settings(array_element_pragma, (low, high)):
+            idx_config = copy.deepcopy(config)
+            idx_config['pv'] += get_array_suffix(
+                config, idx, default=f':%.{expand_digits}d')
+            yield parser._ArrayItemProxy(item, idx), idx_config
 
-            array_element_pragma = dictify_config(config).get('array', '')
-            for idx in parse_array_settings(array_element_pragma, (low, high)):
-                yield (parser._ArrayItemProxy(item, idx),
-                       dictify_config(config, array_index=idx,
-                                      expand_default=expand_default))
+    def merge_subitems(target, source):
+        if PRAGMA not in target:
+            target[PRAGMA] = []
+
+        for key, value in source.items():
+            if key == PRAGMA:
+                target[PRAGMA].extend(value)
+            else:
+                if key not in target:
+                    target[key] = {}
+                merge_subitems(target[key], value)
+
+    subitems = {}
 
     for item in chain:
+        subitems = subitems.get(item.name, {})
         pragmas = list(pragma for pragma in get_pragma(item, name=pragma)
                        if pragma is not None)
         if not pragmas:
@@ -246,9 +297,9 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
                 pragmas = [None]
                 result.append([(item, None)])
                 continue
-            else:
-                # If any pragma in the chain is unset, escape early
-                return []
+
+            # If any pragma in the chain is unset, escape early
+            return []
 
         if item.array_info and (item.data_type.is_complex_type or
                                 item.data_type.is_enum):
@@ -256,7 +307,24 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
         else:
             dictify_func = dictify_scalar
 
-        result.append(list(dictify_func(item)))
+        split_pragma = split_pytmc_pragma('\n'.join(pragmas))
+        alternate_pvs = []
+        for pvname, separated_cfg in separate_configs_by_pv(split_pragma):
+            config = dictify_config(separated_cfg)
+
+            # config will have the SUBITEM key, applicable to its level
+            # in the hierarchy. If it exists, merge it with our current set.
+            if SUBITEM in config:
+                merge_subitems(subitems, config[SUBITEM])
+
+            for key, value in subitems.get(PRAGMA, []):
+                config[key] = value
+
+            alternate_pvs.extend(
+                list(dictify_func(item, pvname, config))
+            )
+
+        result.append(alternate_pvs)
 
     return list(itertools.product(*result))
 
@@ -486,9 +554,8 @@ def parse_array_settings(pragma, dimensions):
             f'{pragma!r}'
         )
 
-    full_range = range(low, high + 1)
     if not pragma:
-        yield from full_range
+        yield from range(low, high + 1)
         return
 
     def _parse_element(elem):
@@ -497,17 +564,18 @@ def parse_array_settings(pragma, dimensions):
 
         # Split by .., such that this will support:
         #   ..to, from.., from..to, from..to..step
-        slice_args = [
-            int(idx) if idx else None
-            for idx in elem.split('..')
-        ]
+        range_args = [int(idx) if idx else None
+                      for idx in elem.split('..')]
 
-        # One exception is that the (normally exclusive slice) upper-bound has
-        # to be converted to being inclusive:
-        if slice_args[1] is not None:
-            slice_args[1] += 1
+        # Ensure we have start, stop, step
+        range_args += [None] * (3 - len(range_args))
+        elem_low, elem_high, elem_step = range_args
 
-        return full_range[slice(*slice_args)]
+        elem_low = low if elem_low is None else elem_low
+        # Add one to make the exclusive upper bound inclusive:
+        elem_high = high + 1 if elem_high is None else elem_high + 1
+        elem_step = 1 if elem_step is None else elem_step
+        return range(elem_low, elem_high, elem_step)
 
     try:
         for elem in pragma.split(','):

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -757,8 +757,11 @@ def chains_from_symbol(symbol, *, pragma: str = 'pytmc',
     else:
         condition = has_pragma
     for full_chain in symbol.walk(condition=condition):
-        for item_and_config in expand_configurations_from_chain(
-                full_chain, allow_no_pragma=allow_no_pragma):
+        configs = itertools.product(
+            *_expand_configurations_from_chain(full_chain,
+                                               allow_no_pragma=allow_no_pragma)
+        )
+        for item_and_config in configs:
             yield SingularChain(dict(item_and_config))
 
 

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -355,6 +355,9 @@ def expand_configurations_from_chain(chain, *, pragma: str = 'pytmc',
     result = _expand_configurations_from_chain(
         chain, pragma=pragma, allow_no_pragma=allow_no_pragma
     )
+    if not result:
+        return []
+
     return list(itertools.product(*result))
 
 

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -212,17 +212,18 @@ def dictify_config(raw_conf, array_index=None):
         config['pv'] += get_array_suffix(config, array_index)
 
     def add_subitem(d, key, value):
+        """Add a subitem `key: value` to dictionary `d`."""
         if '.' in key:
             # The first a.b.c.pragma indicate the sub-(sub-) item for 'pragma':
             child, remainder = key.split('.', 1)
             if child not in d:
                 d[child] = {PRAGMA: []}
-            add_subitem(d[child], remainder, value)
-        else:
-            if key in DISALLOWED_SUBITEMS:
-                raise ValueError(f'Unsupported pragma key in subitem: {key}')
-            # The final key is a pytmc-supported pragma:
-            d[PRAGMA].append((key, value))
+            return add_subitem(d[child], remainder, value)
+
+        if key in DISALLOWED_SUBITEMS:
+            raise ValueError(f'Unsupported pragma key in subitem: {key}')
+        # The final key is a pytmc-supported pragma:
+        d[PRAGMA].append((key, value))
 
     for title, tag in title_tag_pairs:
         if '.' in title:

--- a/pytmc/pragmas.py
+++ b/pytmc/pragmas.py
@@ -54,7 +54,7 @@ ARCHIVE_DEFAULT = {'frequency': 1, 'seconds': 1, 'method': 'scan'}
 # Special, reserved keys:
 SUBITEM = '_subitem_'
 PRAGMA = '_pragma_'
-DISALLOWED_SUBITEMS = {'pv', SUBITEM, PRAGMA}
+DISALLOWED_SUBITEMS = {'pv', SUBITEM, PRAGMA, 'field', 'link'}
 
 # Default for array index expansion:
 EXPAND_DEFAULT = ':%.2d'

--- a/pytmc/tests/test_xml_collector.py
+++ b/pytmc/tests/test_xml_collector.py
@@ -334,18 +334,18 @@ def test_BaseRecordPackage_guess_NELM(chain, tc_type, sing_index, is_str,
 
 def test_scalar():
     item = make_mock_twincatitem(
-        name='tcname', data_type=make_mock_type('DINT'),
+        name='Main.tcname', data_type=make_mock_type('DINT'),
         pragma='pv: PVNAME')
 
     record, = list(pragmas.record_packages_from_symbol(item))
     assert record.pvname == 'PVNAME'
-    assert record.tcname == 'tcname'
+    assert record.tcname == 'Main.tcname'
     assert isinstance(record, IntegerRecordPackage)
 
 
 def test_complex_array():
     array = make_mock_twincatitem(
-        name='array_base',
+        name='Main.array_base',
         data_type=make_mock_type('MY_DUT', is_complex_type=True),
         pragma='pv: ARRAY', array_info=(1, 4))
 
@@ -437,7 +437,7 @@ def test_complex_array():
 )
 def test_complex_array_partial(dimensions, pragma, expected_records):
     array = make_mock_twincatitem(
-        name='array_base',
+        name='Main.array_base',
         data_type=make_mock_type('MY_DUT', is_complex_type=True),
         pragma='\n'.join(('pv: ARRAY', pragma)),
         array_info=dimensions,
@@ -458,7 +458,7 @@ def test_complex_array_partial(dimensions, pragma, expected_records):
 
 def test_enum_array():
     array = make_mock_twincatitem(
-        name='enum_array',
+        name='Main.enum_array',
         data_type=make_mock_type('MY_ENUM', is_enum=True,
                                  enum_dict={1: 'ONE', 2: 'TWO'}),
         pragma='pv: ENUMS', array_info=(1, 4)
@@ -487,7 +487,7 @@ def test_enum_array():
 
 def test_unroll_formatting():
     array = make_mock_twincatitem(
-        name='enum_array',
+        name='Main.enum_array',
         data_type=make_mock_type('MY_ENUM', is_enum=True,
                                  enum_dict={1: 'ONE', 2: 'TWO'}),
         pragma='pv: ENUMS\nexpand: _EXPAND%d', array_info=(1, 4)
@@ -508,12 +508,12 @@ def test_unroll_formatting():
 
 def test_pv_linking():
     item = make_mock_twincatitem(
-        name='tcname', data_type=make_mock_type('DINT'),
+        name='Main.tcname', data_type=make_mock_type('DINT'),
         pragma='pv: PVNAME; link: OTHER:RECORD')
 
     pkg, = list(pragmas.record_packages_from_symbol(item))
     assert pkg.pvname == 'PVNAME'
-    assert pkg.tcname == 'tcname'
+    assert pkg.tcname == 'Main.tcname'
     assert isinstance(pkg, IntegerRecordPackage)
     rec = pkg.generate_output_record()
     assert rec.fields['OMSL'] == 'closed_loop'
@@ -523,7 +523,7 @@ def test_pv_linking():
 
 def test_pv_linking_special():
     struct = make_mock_twincatitem(
-        name='array_base',
+        name='Main.array_base',
         data_type=make_mock_type('MY_DUT', is_complex_type=True),
         pragma='pv: PREFIX')
 


### PR DESCRIPTION
Closes #223 
Fixes as a follow-up to #240 
Closes #242 

Feature point: extends pragma syntax, allowing for forward-references to sub-items (e.g., member variables of function blocks).

If `fbTest` contains a member variable `variable1` with a different `io` setting than desirable for the particular use case, this PR now allows for changing it by way of adding this pragma:

```
variable1.io: io
```

with the overall syntax of `[member].[sub-member].pragma_key: pragma_value`.

Started off with a slightly modified `kfe-motion.tmc` file ([here](https://gist.github.com/klauer/ec6bb07179fafdccc9cacd04f56476a9)), setting `arrStates.array: 1..4` "externally".

Appears to be working locally, but I suspect I won't be catching all edge cases. Going to re-run pytmc on some IOCs and compare the output now.

Debug tool does not show these pragmas cleanly. Not sure I'll have the time to fix it this go around.