### PR TITLE
ENH: check maximum record length when generating db

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,8 @@ Enhancements
 ------------
 
 * Add support for partial pragmas of array elements.
+* Check maximum record length when generating the database file.  This is a
+  constant defined at epics-base compile time, defaulting to 60.
 
 Fixes
 -----

--- a/pytmc/bin/db.py
+++ b/pytmc/bin/db.py
@@ -141,6 +141,21 @@ def process(tmc, *, dbd_file=None, allow_errors=False, show_error_context=True,
         exceptions.append(ex)
         logger.error(message)
 
+    too_long = [record_name for record_name in record_names
+                if len(record_name) > linter.MAX_RECORD_LENGTH]
+    if too_long:
+        message = '\n'.join(
+            [f'Records exceeding the maximum length of '
+             f'{linter.MAX_RECORD_LENGTH} were found:'] +
+            [f'    {record}' for record in too_long]
+        )
+
+        ex = LinterError(message)
+        if not allow_errors:
+            raise ex
+        exceptions.append(ex)
+        logger.error(message)
+
     if dbd_file is not None:
         results, rendered = validate_with_dbd(records, dbd_file)
         for warning in results.warnings:

--- a/pytmc/linter.py
+++ b/pytmc/linter.py
@@ -1,7 +1,10 @@
 import os
+
 import pyPDB.dbd.yacc as _yacc
 import pyPDB.dbdlint as _dbdlint
 from pyPDB.dbdlint import DBSyntaxError
+
+MAX_RECORD_LENGTH = int(os.environ.get('EPICS_MAX_RECORD_LENGTH', '60'))
 
 
 class LinterResults(_dbdlint.Results):


### PR DESCRIPTION
Closes #221 

Looks like:

```
$ pytmc db arb.tmc
ERROR:pytmc.bin.db:Linter errors - failed to create database. To create the database ignoring these errors, use the flag `--allow-errors`
Traceback (most recent call last):
  File "/Users/klauer/docs/Repos/pytmc/pytmc/bin/db.py", line 293, in main
    debug=debug,
  File "/Users/klauer/docs/Repos/pytmc/pytmc/bin/db.py", line 155, in process
    raise ex
pytmc.bin.db.LinterError: Records exceeding the maximum length of 60 were found:
    $(PREFIX)FFO:01:FF:001:Info:PathOFDIJOIWEJFOIJWEFOIJWEOFIJWEOIFJWEOIFJ_RBV
    $(PREFIX)FFO:01:FF:002:Info:PathOFDIJOIWEJFOIJWEFOIJWEOFIJWEOIFJWEOIFJ_RBV
```